### PR TITLE
feat: add a dexterity behaviour for ISearchReplaceable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added a behaviour to add ISearchReplaceable on Dexterity content types.
+  Also added a profile to set this behavior on some content types.
+  [Gagaro]
 
 
 5.1 (2015-10-27)

--- a/collective/searchandreplace/configure.zcml
+++ b/collective/searchandreplace/configure.zcml
@@ -6,7 +6,7 @@
    xmlns:plone="http://namespaces.plone.org/plone"
    i18n_domain="collective.searchandreplace">
 
-  <include package="zope.formlib" file="configure.zcml" />
+  <include package="five.formlib" file="configure.zcml" />
 
   <!-- See also the permission string in the __init__.py. -->
   <permission

--- a/collective/searchandreplace/configure.zcml
+++ b/collective/searchandreplace/configure.zcml
@@ -3,7 +3,10 @@
    xmlns:five="http://namespaces.zope.org/five"
    xmlns:i18n="http://namespaces.zope.org/i18n"
    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+   xmlns:plone="http://namespaces.plone.org/plone"
    i18n_domain="collective.searchandreplace">
+
+  <include package="zope.formlib" file="configure.zcml" />
 
   <!-- See also the permission string in the __init__.py. -->
   <permission
@@ -47,6 +50,14 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:registerProfile
+     name="dexterity"
+     title="collective.searchandreplace (Dexterity)"
+     directory="profiles/dexterity"
+     description="Add the SearchReplaceable to dexterity contents."
+     provides="Products.GenericSetup.interfaces.EXTENSION"
+     />
+
   <utility
      provides=".interfaces.ISearchReplaceUtility"
      factory=".searchreplaceutility.SearchReplaceUtility"
@@ -71,5 +82,11 @@
   <class class="Products.ATContentTypes.content.folder.ATFolder">
     <implements interface="collective.searchandreplace.interfaces.ISearchReplaceable" />
   </class>
+
+  <plone:behavior
+    title="Search and Replaceable"
+    description="Allow to run the search and replace feature from this type of document."
+    provides="collective.searchandreplace.interfaces.ISearchReplaceable"
+    />
 
 </configure>

--- a/collective/searchandreplace/profiles/dexterity/types.xml
+++ b/collective/searchandreplace/profiles/dexterity/types.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+ <object meta_type="Dexterity FTI" name="Document" />
+ <object meta_type="Dexterity FTI" name="File" />
+ <object meta_type="Dexterity FTI" name="Folder" />
+ <object meta_type="Dexterity FTI" name="Image" />
+</object>

--- a/collective/searchandreplace/profiles/dexterity/types/Document.xml
+++ b/collective/searchandreplace/profiles/dexterity/types/Document.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="Document" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="behaviors" purge="false">
+  <element value="collective.searchandreplace.interfaces.ISearchReplaceable"/>
+ </property>
+</object>

--- a/collective/searchandreplace/profiles/dexterity/types/File.xml
+++ b/collective/searchandreplace/profiles/dexterity/types/File.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="File" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="behaviors" purge="true">
+  <element value="collective.searchandreplace.interfaces.ISearchReplaceable"/>
+ </property>
+</object>

--- a/collective/searchandreplace/profiles/dexterity/types/Folder.xml
+++ b/collective/searchandreplace/profiles/dexterity/types/Folder.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="Folder" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="behaviors" purge="false">
+  <element value="collective.searchandreplace.interfaces.ISearchReplaceable"/>
+ </property>
+</object>

--- a/collective/searchandreplace/profiles/dexterity/types/Image.xml
+++ b/collective/searchandreplace/profiles/dexterity/types/Image.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="Image" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="behaviors" purge="false">
+  <element value="collective.searchandreplace.interfaces.ISearchReplaceable"/>
+ </property>
+</object>


### PR DESCRIPTION
I added a behavior to be able to chose from which content types the search should be available.

Also, the action is in the `object` category, but it would be better in the `object_buttons` one in Plone 5. Should a `plone5` be created?