### PR TITLE
fix: ensure we get the attributes of the base object in _getRawText

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 6.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix ensure we get the attributes of the base object in _getRawText.
+  [Gagaro]
 
 
 6.0.2 (2016-02-08)

--- a/collective/searchandreplace/searchreplaceutility.py
+++ b/collective/searchandreplace/searchreplaceutility.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from Acquisition import aq_parent
+from Acquisition import aq_parent, aq_base
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.utils import getToolByName
 from Products.statusmessages.interfaces import IStatusMessage
@@ -257,6 +257,7 @@ class SearchReplaceUtility(object):
 
     def _getRawText(self, obj):
         text = None
+        obj = aq_base(obj)
         if hasattr(obj, 'getText'):
             baseunit = obj.getField('text').getRaw(obj, raw=True)
             if isinstance(baseunit.raw, unicode):


### PR DESCRIPTION
We have an error if we get an object without `getText` but which has a parent with it.