### PR TITLE
feat: add a setting to limit number of character shown before and after

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 6.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add a setting to limit number of character shown before and after
+  [Gagaro]
 
 
 6.0.3 (2016-02-15)

--- a/collective/searchandreplace/browser/searchreplacetable.pt
+++ b/collective/searchandreplace/browser/searchreplacetable.pt
@@ -5,7 +5,9 @@
      tal:define="isFolderish context/isPrincipiaFolderish|nothing;
 		 items view/getItems;
 		 findText request/form.findWhat|nothing;
-		 replaceText request/form.replaceWith|nothing;">
+		 replaceText request/form.replaceWith|nothing;
+         maximum_text_characters python:context.portal_registry['collective.searchandreplace.maximum_text_characters']
+        ">
 
   <label for="form.affectedContent">
     <span i18n:translate="">Affected Content</span>
@@ -54,10 +56,10 @@
 	  </td>
 	  <td tal:content="itemline">1</td>
 	  <td>
-	    <span tal:replace="itemBeforeText" /><i><span style="color: red" tal:content="itemFindText" /></i><span tal:replace="itemAfterText" />
+	    <span tal:condition="python: len(itemBeforeText) > maximum_text_characters">[...]</span><span tal:replace="python: itemBeforeText[-maximum_text_characters:]" /><i><span style="color: red" tal:content="itemFindText" /></i><span tal:replace="python: itemAfterText[:maximum_text_characters]" /><span tal:condition="python: len(itemAfterText) > maximum_text_characters">[...]</span>
 	  </td>
 	  <td>
-	    <span tal:replace="itemBeforeText" /><i><span style="color: green" tal:content="replaceText" /></i><span tal:replace="itemAfterText" />
+	    <span tal:condition="python: len(itemBeforeText) > maximum_text_characters">[...]</span><span tal:replace="python: itemBeforeText[-maximum_text_characters:]" /><i><span style="color: green" tal:content="replaceText" /></i><span tal:replace="python: itemAfterText[:maximum_text_characters]" /><span tal:condition="python: len(itemAfterText) > maximum_text_characters">[...]</span>
 	  </td>
 	</tr>
       </tal:block>

--- a/collective/searchandreplace/configure.zcml
+++ b/collective/searchandreplace/configure.zcml
@@ -50,6 +50,17 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeSteps
+      source="1001"
+      destination="1002"
+      profile="collective.searchandreplace:default">
+    <genericsetup:upgradeStep
+        title="Update registry"
+        description="Add maximum_text_characters settings"
+        handler=".upgrade.run_registry_step"
+        />
+  </genericsetup:upgradeSteps>
+
   <genericsetup:registerProfile
      name="dexterity"
      title="collective.searchandreplace (Dexterity)"

--- a/collective/searchandreplace/profiles/default/metadata.xml
+++ b/collective/searchandreplace/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>1001</version>
+    <version>1002</version>
 </metadata>

--- a/collective/searchandreplace/profiles/default/registry.xml
+++ b/collective/searchandreplace/profiles/default/registry.xml
@@ -1,0 +1,10 @@
+<registry>
+    <record name="collective.searchandreplace.maximum_text_characters">
+        <field type="plone.registry.field.Int">
+            <default>50</default>
+            <description xmlns:ns0="http://xml.zope.org/namespaces/i18n" ns0:domain="SearchAndReplace" ns0:translate="">The maximum number of characters to show before and after the found text.</description>
+            <required>False</required>
+            <title xmlns:ns0="http://xml.zope.org/namespaces/i18n" ns0:domain="SearchAndReplace" ns0:translate="">Maximum text characters</title>
+        </field>
+    </record>
+</registry>

--- a/collective/searchandreplace/upgrade.py
+++ b/collective/searchandreplace/upgrade.py
@@ -11,3 +11,7 @@ def run_actions_step(context):
 
 def run_rolemap_step(context):
     context.runImportStepFromProfile(PROFILE_ID, 'rolemap')
+
+
+def run_registry_step(context):
+    context.runImportStepFromProfile(PROFILE_ID, 'plone.app.registry')


### PR DESCRIPTION
Only show 50 characters (by default) before and after the found pattern. It can be change in the portal_registry.