### PR TITLE
fix: keep table and form values when replacing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 6.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Keep table and form values when replacing.
+  [Gagaro]
 
 
 6.0.3 (2016-02-15)

--- a/collective/searchandreplace/browser/searchreplaceform.py
+++ b/collective/searchandreplace/browser/searchreplaceform.py
@@ -75,6 +75,7 @@ class SearchReplaceForm(AddForm):
             name=u'Replace')
     def action_replace(self, action, data):
         """ Replace text for all files. """
+        self.form_reset = False
         srutil = getUtility(ISearchReplaceUtility)
         if 'form.affectedContent' in self.request:
             # Do only the selected items
@@ -110,8 +111,6 @@ class SearchReplaceForm(AddForm):
                 _(u'Search text replaced in all ${items} instance(s).',
                   mapping={'items': replaced}),
                 type='info')
-        self.request.response.redirect(self.context.absolute_url())
-        return ''
 
     @action(_(u'Reset'),
             validator=None,

--- a/collective/searchandreplace/browser/searchreplacetable.pt
+++ b/collective/searchandreplace/browser/searchreplacetable.pt
@@ -1,7 +1,7 @@
 <div class="field"
      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
      i18n:domain="SearchAndReplace"
-     tal:condition="python: request.has_key('form.actions.Preview')"
+     tal:condition="python: request.has_key('form.actions.Preview') or request.has_key('form.actions.Replace')"
      tal:define="isFolderish context/isPrincipiaFolderish|nothing;
 		 items view/getItems;
 		 findText request/form.findWhat|nothing;


### PR DESCRIPTION
Easier to use when there are a lot of results or when using #18 