### PR TITLE
Show link to searchreplace form in parent folder.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 6.0.4 (unreleased)
 ------------------
 
+- Show link to searchreplace form in parent folder when you are not
+  viewing a folderish item.
+  [maurits]
+
 - Add edit links in table.
   [Gagaro]
 

--- a/collective/searchandreplace/browser/pageform.pt
+++ b/collective/searchandreplace/browser/pageform.pt
@@ -45,6 +45,10 @@
         <div class="documentDescription" tal:content="view/description|nothing">Description</div>
 
         <div id="content-core">
+          <p tal:condition="not:context/isPrincipiaFolderish|nothing">
+            <a href="../@@searchreplaceform" i18n:translate="">Search and replace in parent folder</a>
+          </p>
+
             <form action="." metal:define-macro="master"
                   tal:attributes="action request/URL;
                                   class string:kssattr-formname-${view/__name__}"


### PR DESCRIPTION
This is when you are not viewing a folderish item.

I thought about letting the tab link to the searchreplaceform on the parent folder (with `folder_url` in `actions.xml`) but that is not always a good idea, at least a test started failing because of permission issues.  A simple extra link like in this pull request seems better.