### PR TITLE
feat: add confirmation prompt when replacing without viewing first.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 6.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add confirmation prompt when replacing without viewing first.
+  [Gagaro]
 
 
 6.0.4 (2016-03-23)

--- a/collective/searchandreplace/browser/pageform.pt
+++ b/collective/searchandreplace/browser/pageform.pt
@@ -150,6 +150,17 @@
             </form>
 
 
+            <script>
+                if ($('input#form\\.affectedContent').length == 0) {
+                    $('input#form\\.actions\\.Replace').click(function(e) {
+                        var replace = confirm('Are you sure you want to replace without previewing first?');
+                        if (!replace) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }
+                    });
+                }
+            </script>
             <script type="text/javascript"
                 tal:define="extra_script view/extra_script | nothing"
                 tal:condition="extra_script"


### PR DESCRIPTION
This ask confirmation if the user wants to replace without viewing and selecting first. It should avoid mistakes when miss-clicking.

However, I'm not sure on how to translate the string in javascript so it is compatible in plone 4 and plone 5. Do you have any idea on how to do that?