### PR TITLE
Fast search option: search in SearchableText

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,7 @@ Changelog
 7.0 (unreleased)
 ----------------
 
-- Added option in form to use fast search.  By default this is
-  checked.  This means we use the catalog, instead of waking up every
-  object in the path.  [maurits]
+Breaking changes:
 
 - Removed ``ISearchReplaceable`` behavior.  This was introduced in version 6.
   Kept the interface for backwards compatibility, but it is not used anymore.
@@ -26,12 +24,22 @@ Changelog
   This fixes issue https://github.com/collective/collective.searchandreplace/issues/25
   [maurits]
 
+New features:
+
+- Added option in form to use fast search.  By default this is
+  checked.  This means we use the catalog, instead of waking up every
+  object in the path.  [maurits]
+
 - Search and replace in all text fields.  Removed special cases for
   Description and Text/Body field: these are handled the same as other
   text fields now.  TextLine fields and StringFields are ignored,
   except for the Title field.  [maurits]
 
 - Ported tests to plone.app.testing.  [maurits]
+
+- Added number of contents affected after a search. [Gagaro]
+
+Bug fixes:
 
 - Fixed Travis (continuous integration) test setup for Plone 5.  [maurits]
 
@@ -40,8 +48,6 @@ Changelog
 - Conditionally load zcml for dexterity behavior/profile and ATContentTypes.  [maurits]
 
 - Added ``plone.resource`` to our requirements for our resources.  [maurits]
-
-- Added number of contents affected after a search. [Gagaro]
 
 
 6.0.4 (2016-03-23)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 7.0 (unreleased)
 ----------------
 
+- Added option in form to use fast search.  By default this is
+  checked.  This means we use the catalog, instead of waking up every
+  object in the path.  [maurits]
+
 - Removed ``ISearchReplaceable`` behavior.  This was introduced in version 6.
   Kept the interface for backwards compatibility, but it is not used anymore.
   Instead, by default all types are searched and replaced.

--- a/README.rst
+++ b/README.rst
@@ -4,21 +4,17 @@ Introduction
 .. image:: https://secure.travis-ci.org/collective/collective.searchandreplace.png?branch=master
    :target: https://travis-ci.org/#!/collective/collective.searchandreplace
 
-The collective.searchandreplace product is a Plone Add-on designed to
-find and replace text in Plone content objects, namely titles,
-descriptions, and document text. It operates over single or multiple
-Plone content objects and can show a preview of changes as well as
-immediately perform them.
+The collective.searchandreplace product is a Plone Add-on designed to find and replace text in Plone content objects.
+It looks in title, description, and document text, and since version 7 it looks in all text fields.
+It operates over single or multiple Plone content objects and can show a preview of changes as well as immediately perform them.
 
-Optional features include being able to control searching in
-subfolders, and matching based on case sensitivity/insensitivity.
+Features include:
 
-Note: since version 6.0, we search and replace only items that
-implement the ``ISearchReplaceable`` interface.  Since this version,
-this interface can be set on dexterity content types using a
-behavior.  Note that when you enable or disable this interface on a
-content type, either through the web or in code, you should reindex
-the ``object_provides`` index in the ``portal_catalog``.
+- being able to control searching in subfolders
+- matching based on case sensitivity/insensitivity
+- maximum number of results
+- fast search using the catalog by default
+- disable the fast search to be able to search and replace raw html tags, for example replace ``<strong>text</strong>`` by ``<em>text</em>``
 
 
 Compatibility

--- a/collective/searchandreplace/browser/searchreplaceform.py
+++ b/collective/searchandreplace/browser/searchreplaceform.py
@@ -56,6 +56,20 @@ class ISearchReplaceForm(Interface):
         default=False,
         required=True)
 
+    onlySearchableText = Bool(
+        title=_(u'Fast search'),
+        description=_(
+            u'Use the catalog to search, just like the search form does. '
+            'This only finds keywords, not html tags. '
+            'You might have some text fields that are not found this way, '
+            'so if not checked, you may find more content, '
+            'but it will be slower. '
+            'Regardless of this setting, when at least one match is found , '
+            'text in all text fields may be replaced.'),
+        required=False,
+        default=True,
+    )
+
 
 class SearchReplaceForm(AddForm):
     """ """
@@ -104,7 +118,9 @@ class SearchReplaceForm(AddForm):
                 matchCase=data['matchCase'],
                 replaceText=data['replaceWith'],
                 doReplace=True,
-                searchItems=items)
+                searchItems=items,
+                onlySearchableText=data['onlySearchableText'],
+            )
             IStatusMessage(self.request).addStatusMessage(
                 _(u'Search text replaced in ${replaced} of ${items} '
                   'instance(s).',
@@ -118,6 +134,7 @@ class SearchReplaceForm(AddForm):
                 searchSubFolders=data.get('searchSubfolders', False),
                 matchCase=data['matchCase'],
                 replaceText=data['replaceWith'],
+                onlySearchableText=data['onlySearchableText'],
                 doReplace=True)
             IStatusMessage(self.request).addStatusMessage(
                 _(u'Search text replaced in all ${items} instance(s).',

--- a/collective/searchandreplace/browser/searchreplacetable.py
+++ b/collective/searchandreplace/browser/searchreplacetable.py
@@ -29,13 +29,16 @@ class SearchReplaceTable(BrowserView):
             maxResults = int(self.request['form.maxResults'])
         else:
             maxResults = None
+        onlySearchableText = 'form.onlySearchableText' in self.request
         # Get search results
         results = srutil.searchObjects(
             self.context,
             stext,
             searchSubFolders=subfolders,
             matchCase=mcase,
-            maxResults=maxResults)
+            maxResults=maxResults,
+            onlySearchableText=onlySearchableText,
+        )
         return results
 
     def getRelativePath(self, path):

--- a/collective/searchandreplace/profiles/testing-dexterity/types/SampleType.xml
+++ b/collective/searchandreplace/profiles/testing-dexterity/types/SampleType.xml
@@ -19,6 +19,7 @@
   <property name="behaviors" purge="false">
     <element value="plone.app.content.interfaces.INameFromTitle"/>
     <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
+   <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
   </property>
   <alias from="(Default)" to="(dynamic view)"/>
   <alias from="edit" to="@@edit"/>

--- a/collective/searchandreplace/searchreplaceutility.py
+++ b/collective/searchandreplace/searchreplaceutility.py
@@ -53,6 +53,7 @@ class SearchReplaceUtility(object):
             mc = kwargs['matchCase']
         else:
             mc = False
+        onlySearchableText = kwargs.get('onlySearchableText', True)
         if 'replaceText' in kwargs:
             rtext = kwargs['replaceText']
             if rtext is None:
@@ -88,6 +89,8 @@ class SearchReplaceUtility(object):
         settings = registry.forInterface(ISearchReplaceSettings, check=False)
         if settings.restrict_searchable_types:
             parameters['portal_type'] = settings.enabled_types
+        if onlySearchableText:
+            parameters['SearchableText'] = '*{0}*'.format(find)
         brains = catalog(**parameters)
         memship = getToolByName(context, 'portal_membership')
         checkPermission = memship.checkPermission

--- a/collective/searchandreplace/testing.py
+++ b/collective/searchandreplace/testing.py
@@ -22,6 +22,8 @@ class SearchReplaceLayer(PloneSandboxLayer):
         if MAJOR_PLONE_VERSION >= 5:
             import plone.app.contenttypes
             self.loadZCML(package=plone.app.contenttypes)
+            import collective.dexteritytextindexer
+            self.loadZCML(package=collective.dexteritytextindexer)
         else:
             # Needed for our Archetypes SampleType.
             z2.installProduct(app, 'collective.searchandreplace')
@@ -70,7 +72,7 @@ def create_doc(container, id='page', title=u'Title of page', text=u''):
 
 
 def edit_content(context, title=None, description=None, text=None,
-                 rich=None, plain=None, line=None):
+                 rich=None, plain=None, line=None, unsearchable=None):
     if MAJOR_PLONE_VERSION >= 5:
         # Dexterity
         if title is not None:
@@ -85,6 +87,8 @@ def edit_content(context, title=None, description=None, text=None,
             context.plain = plain
         if line is not None:
             context.line = line
+        if unsearchable is not None:
+            context.unsearchable = rich_text(unsearchable)
     else:
         # Archetypes
         if title is not None:
@@ -99,3 +103,6 @@ def edit_content(context, title=None, description=None, text=None,
             context.setPlain(plain)
         if line is not None:
             context.setLine(line)
+        if unsearchable is not None:
+            context.setUnsearchable(unsearchable)
+    context.reindexObject()

--- a/collective/searchandreplace/tests/archetypes.py
+++ b/collective/searchandreplace/tests/archetypes.py
@@ -49,6 +49,16 @@ SampleTypeSchema = BaseSchema.copy() + MetadataSchema(()) + Schema((
             label=u'Text Line')
     ),
 
+    TextField(
+        'unsearchable',
+        required=False,
+        searchable=False,
+        default_output_type='text/x-html-safe',
+        widget=RichWidget(
+            description='',
+            label=u'Unsearchable Text')
+    ),
+
 ))
 
 

--- a/collective/searchandreplace/tests/sample_type_schema.xml
+++ b/collective/searchandreplace/tests/sample_type_schema.xml
@@ -1,22 +1,32 @@
 <model xmlns="http://namespaces.plone.org/supermodel/schema"
        xmlns:marshal="http://namespaces.plone.org/supermodel/marshal"
        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+       xmlns:indexer="http://namespaces.plone.org/supermodel/indexer">
        i18n:domain="plone">
   <schema>
-    <field name="rich" type="plone.app.textfield.RichText">
+    <field name="rich" type="plone.app.textfield.RichText"
+           indexer:searchable="true">
       <description />
       <required>False</required>
       <title>Rich Text</title>
     </field>
-    <field name="plain" type="zope.schema.Text">
+    <field name="plain" type="zope.schema.Text"
+           indexer:searchable="true">
       <description />
       <required>False</required>
       <title>Plain Text</title>
     </field>
-    <field name="line" type="zope.schema.TextLine">
+    <field name="line" type="zope.schema.TextLine"
+           indexer:searchable="true">
       <description>Textlines are ignored by searchreplace. You need text or richtext.</description>
       <required>False</required>
       <title>Text Line</title>
+    </field>
+    <field name="unsearchable" type="plone.app.textfield.RichText"
+           indexer:searchable="">
+      <description />
+      <required>False</required>
+      <title>Unsearchable Text</title>
     </field>
   </schema>
 </model>

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     ],
     extras_require={
         'test': [
+            'collective.dexteritytextindexer',
             'plone.app.testing',
             'plone.api',
         ],


### PR DESCRIPTION
This branch is based on pull request #28: it includes those commits. They are not really related, but they partly touch the same code.

This adds an option in the search form. I have [another branch](https://github.com/collective/collective.searchandreplace/tree/maurits-searchabletext-in-controlpanel) where I initially added this option in the control panel instead. In the form it is more flexible as the end user has the choice. This has the automatic downside that the end user has yet another option, making the form more complex. But at least the search/replacing is now faster by default. And a Manager will not get requests to temporarily switch the setting in the control panel.

@Gagaro Do you agree with this change, and with putting it in the form?