### PR TITLE
Allow overriding the permission that is checked on an object.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,12 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Allow overriding the permission that is checked on an object.  By
+  default this is the Modify portal content permission.  But when you
+  have setup a workflow that does not allow editing published content,
+  for example when you require doing changes with check-out/check-in
+  from Iterate, then you may want to use a different permission.  You
+  can then override the utility in your own code.  [maurits]
 
 Bug fixes:
 

--- a/collective/searchandreplace/searchreplaceutility.py
+++ b/collective/searchandreplace/searchreplaceutility.py
@@ -41,6 +41,9 @@ def _to_unicode(s):
 class SearchReplaceUtility(object):
     """ Search and replace utility. """
 
+    # Permission to check before modifying content.
+    permission = ModifyPortalContent
+
     def searchObjects(self, context, find, **kwargs):
         """ Search objects and optionally do a replace. """
         # Get search parameters
@@ -106,7 +109,7 @@ class SearchReplaceUtility(object):
                     logger.warn('getObject failed for %s', ipath)
                     continue
                 # Does the user have the modify permission on this object?
-                if not checkPermission(ModifyPortalContent, obj):
+                if not checkPermission(self.permission, obj):
                     continue
                 # If there is a filtered list of items, and it
                 # is in the list, or if there is no filter


### PR DESCRIPTION
By default this is the Modify portal content permission.  But when you have setup a workflow that does not allow editing published content, for example when you require doing changes with check-out/check-in from Iterate, then you may want to use a different permission.  You can then override the utility in your own code.