### PR TITLE
fix: do not use base object when replacing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Do not use base object when replacing [Gagaro]
 
 
 7.1.1 (2016-08-02)

--- a/collective/searchandreplace/searchreplaceutility.py
+++ b/collective/searchandreplace/searchreplaceutility.py
@@ -324,10 +324,10 @@ class SearchReplaceUtility(object):
         return getRawText(obj, fieldname)
 
     def _setTextField(self, obj, fieldname, text):
-        obj = aq_base(obj)
-        if getattr(obj, 'Schema', None):
+        obj_base = aq_base(obj)
+        if getattr(obj_base, 'Schema', None):
             # Archetypes
-            field = obj.getField(fieldname)
+            field = obj_base.getField(fieldname)
             if field is None:
                 logger.warn('Field %s not found for %s',
                             fieldname, obj.getId())
@@ -335,7 +335,7 @@ class SearchReplaceUtility(object):
             field.set(obj, text)
         else:
             # Dexterity
-            field = self._getField(obj, fieldname)
+            field = self._getField(obj_base, fieldname)
             if field is None:
                 logger.warn('Field %s not found for %s',
                             fieldname, obj.getId())


### PR DESCRIPTION
I had a issue with collective.EasyNewsletter, where they use Acquisition to get a parameter in the parent content for a default value. The defaut value is used by the field class when setting another value. Thus I had an attribute error when replacing those contents.

It now use the base object only to get the field and check it exists. The replacement is made on the object in its context.