### PR TITLE
Enable search and replace on lines fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 version: ~> 1.0
-import: collective/buildout.plonetest:travis/default.yml
+import: collective/buildout.plonetest:travis/pytest.yml@pytest
 matrix:
   include:
     - python: "2.7"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 8.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Enable search and replace on lines fields, Archetypes ``ILinesField`` and dexterity ``ITuple`` with ``value_type==ITextLine``
+  Can be enabled with registry ``include_lines_fields`` to True
+  [gotcha]
+
 
 
 8.0.0 (2020-03-06)
@@ -14,7 +17,7 @@ Changelog
   [maurits, gotcha]
 
 - Enable search and replace on string fields, Archetypes ``IStringField`` and dexterity ``ITextLine``
-  Disable by putting registry ``include_textline_fields`` to False
+  Can be disabled with registry ``include_textline_fields`` to False
   [gotcha]
 
 - Translate field names in preview table

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 8.0.1 (unreleased)
 ------------------
 
+- use pytest as test runner
+  [gotcha]
+
 - Enable search and replace on lines fields, Archetypes ``ILinesField`` and dexterity ``ITuple`` with ``value_type==ITextLine``
   Can be enabled with registry ``include_lines_fields`` to True
   [gotcha]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -10,6 +10,7 @@ package-extras = [test]
 # omelette for development but not on Travis
 parts += omelette
          pytest
+         plonesite
 
 [buildout:os.environ.get('TRAVIS', 'false') == 'true']
 parts += createcoverage
@@ -20,6 +21,12 @@ zc.buildout = 2.13.2
 py = 1.8.1
 pytest = 4.6.9
 gocept.pytestlayer = 6.2
+zodbupdate = 0.5
+collective.upgrade = 1.5
+collective.recipe.plonesite = 1.11.0
+
+[instance]
+eggs += collective.upgrade
 
 [omelette]
 recipe = collective.recipe.omelette
@@ -30,3 +37,10 @@ recipe = zc.recipe.egg
 eggs = collective.searchandreplace [test, pytest]
 relative-paths = true
 entry-points = pytest=pytest:main
+
+[plonesite]
+recipe = collective.recipe.plonesite
+profiles-initial = plonetheme.sunburst:default
+                   collective.searchandreplace:default
+upgrade-portal = true
+upgrade-profiles = collective.searchandreplace:default

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/pytest/pytest-5.x.cfg
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
 
 package-name = collective.searchandreplace
@@ -9,8 +9,6 @@ package-extras = [test]
 [buildout:os.environ.get('TRAVIS', 'false') != 'true']
 # omelette for development but not on Travis
 parts += omelette
-         pytest
-         plonesite
 
 [buildout:os.environ.get('TRAVIS', 'false') == 'true']
 parts += createcoverage
@@ -22,8 +20,16 @@ py = 1.8.1
 pytest = 4.6.9
 gocept.pytestlayer = 6.2
 zodbupdate = 0.5
-collective.upgrade = 1.5
 collective.recipe.plonesite = 1.11.0
+
+[versions:os.environ.get('PLONE_VERSION', '4.3').startswith('4.')]
+collective.upgrade = 1.5
+
+[versions:os.environ.get('PLONE_VERSION', '4.3') == '5.1']
+collective.upgrade = 1.5
+
+[versions:os.environ.get('PLONE_VERSION', '4.3') == '5.2']
+collective.upgrade = 1.6
 
 [instance]
 eggs += collective.upgrade
@@ -40,7 +46,13 @@ entry-points = pytest=pytest:main
 
 [plonesite]
 recipe = collective.recipe.plonesite
-profiles-initial = plonetheme.sunburst:default
-                   collective.searchandreplace:default
 upgrade-portal = true
 upgrade-profiles = collective.searchandreplace:default
+
+[plonesite:os.environ.get('PLONE_VERSION', '4.3').startswith('4.')]
+profiles-initial = plonetheme.sunburst:default
+                   collective.searchandreplace:default
+
+[plonesite:os.environ.get('PLONE_VERSION', '4.3').startswith('5.')]
+profiles-initial = plonetheme.barceloneta:default
+                   collective.searchandreplace:default

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -24,12 +24,15 @@ collective.recipe.plonesite = 1.11.0
 
 [versions:os.environ.get('PLONE_VERSION', '4.3').startswith('4.')]
 collective.upgrade = 1.5
+zodbupdate = 0.5
 
 [versions:os.environ.get('PLONE_VERSION', '4.3') == '5.1']
 collective.upgrade = 1.5
+zodbupdate = 0.5
 
 [versions:os.environ.get('PLONE_VERSION', '4.3') == '5.2']
 collective.upgrade = 1.6
+zodbupdate = 1.4
 
 [instance]
 eggs += collective.upgrade

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,16 +6,27 @@ extends =
 package-name = collective.searchandreplace
 package-extras = [test]
 
-parts += createcoverage
-
 [buildout:os.environ.get('TRAVIS', 'false') != 'true']
-# omelette for development but not do on Travis
+# omelette for development but not on Travis
 parts += omelette
+         pytest
+
+[buildout:os.environ.get('TRAVIS', 'false') == 'true']
+parts += createcoverage
 
 [versions]
 setuptools = 44.0.0
 zc.buildout = 2.13.2
+py = 1.8.1
+pytest = 4.6.9
+gocept.pytestlayer = 6.2
 
 [omelette]
 recipe = collective.recipe.omelette
-eggs = ${test:eggs}
+eggs = ${pytest:eggs}
+
+[pytest]
+recipe = zc.recipe.egg
+eggs = collective.searchandreplace [test, pytest]
+relative-paths = true
+entry-points = pytest=pytest:main

--- a/collective/searchandreplace/configure.zcml
+++ b/collective/searchandreplace/configure.zcml
@@ -89,7 +89,17 @@
         import_steps="plone.app.registry"
     />
   </genericsetup:upgradeSteps>
-
+  <genericsetup:upgradeSteps
+    source="2001"
+    destination="2002"
+    profile="collective.searchandreplace:default">
+    <genericsetup:upgradeDepends
+        title="Update registry"
+        description="Add include_lines_fields settings"
+        import_profile="collective.searchandreplace:default"
+        import_steps="plone.app.registry"
+    />
+  </genericsetup:upgradeSteps>
   <utility
      provides=".interfaces.ISearchReplaceUtility"
      factory=".searchreplaceutility.SearchReplaceUtility"

--- a/collective/searchandreplace/interfaces.py
+++ b/collective/searchandreplace/interfaces.py
@@ -78,7 +78,7 @@ class ISearchReplaceSettings(Interface):
         required=False,
         default=True,
     )
- 
+
     include_textline_fields = schema.Bool(
         title=_(u"Search also textline fields"),
         description=_(
@@ -88,4 +88,15 @@ class ISearchReplaceSettings(Interface):
         ),
         required=False,
         default=True,
+    )
+
+    include_lines_fields = schema.Bool(
+        title=_(u"Search also lines fields"),
+        description=_(
+            u"If checked, multiple lines fields like Subject"
+            u"will also be searched and replaced,"
+            u"not only title and text fields",
+        ),
+        required=False,
+        default=False,
     )

--- a/collective/searchandreplace/interfaces.py
+++ b/collective/searchandreplace/interfaces.py
@@ -83,8 +83,8 @@ class ISearchReplaceSettings(Interface):
         title=_(u"Search also textline fields"),
         description=_(
             u"If checked, single line fields "
-            u"will also be searched and replaced,"
-            u"not only title and text fields",
+            u"will also be searched and replaced, "
+            u"not only title and text fields.",
         ),
         required=False,
         default=True,
@@ -93,9 +93,9 @@ class ISearchReplaceSettings(Interface):
     include_lines_fields = schema.Bool(
         title=_(u"Search also lines fields"),
         description=_(
-            u"If checked, multiple lines fields like Subject"
-            u"will also be searched and replaced,"
-            u"not only title and text fields",
+            u"If checked, multiple lines fields like subject "
+            u"will also be searched and replaced, "
+            u"not only title and text fields.",
         ),
         required=False,
         default=False,

--- a/collective/searchandreplace/profiles/default/metadata.xml
+++ b/collective/searchandreplace/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2001</version>
+  <version>2002</version>
 </metadata>

--- a/collective/searchandreplace/pytests/test_upgrade.py
+++ b/collective/searchandreplace/pytests/test_upgrade.py
@@ -1,93 +1,12 @@
-import sys
-import os
-import time
 import pytest
-import subprocess
 import requests
 import pathlib2 as pathlib
-import socket
-from contextlib import closing
-
-
-def check_socket(host, port):
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-        return sock.connect_ex((host, port)) == 0
+from zope_instance import ZopeInstance
 
 
 @pytest.fixture
 def plone_instance(tmp_path, pytestconfig):
-    buildout_exe = pathlib.Path(
-        pytestconfig.invocation_dir,
-        sys.argv[0]
-    ).parent.joinpath('buildout')
-    return ZopeInstance(tmp_path, buildout_exe, pytestconfig.rootdir)
-
-
-class ZopeInstance(object):
-
-    def __init__(
-            self,
-            tmp_path,
-            buildout_exe,
-            package_path,
-            host='127.0.0.1',
-            port=8080,
-            ):
-        self.host = host
-        self.port = port
-        buildout_cfg = pathlib.Path(tmp_path, 'buildout.cfg')
-        buildout = u"""
-[buildout]
-extends =  %(package_path)s/buildout.cfg
-develop =  %(package_path)s
-""" % dict(package_path=package_path)
-        with buildout_cfg.open("w") as f:
-            f.write(buildout)
-        os.chdir(str(tmp_path))
-        subprocess.call([str(buildout_exe), "bootstrap"])
-
-        output = subprocess.check_output(
-            ["bin/buildout", "query", "buildout:develop"]
-        )
-        assert str(package_path) in output
-
-        output = subprocess.check_output(
-            ["bin/buildout", "query", "instance:recipe"]
-        )
-        assert 'plone.recipe.zope2instance' in output
-
-        output = subprocess.check_output(
-            ["bin/buildout", "query", "plonesite:recipe"]
-        )
-        assert 'collective.recipe.plonesite' in output
-
-    def run_buildouts(self, from_version):
-        subprocess.call(
-            [
-                "bin/buildout",
-                "buildout:develop=",
-                "versions:%s" % from_version,
-                "install",
-                "instance",
-                "plonesite"
-            ]
-        )
-        assert pathlib.Path("bin/instance").exists()
-        subprocess.call(["bin/buildout", "install", "instance", "plonesite"])
-        assert pathlib.Path("bin/instance").exists()
-
-    def start(self):
-        subprocess.call(["bin/instance", "start"])
-        while not check_socket(self.host, self.port):
-            time.sleep(.3)
-
-    def stop(self):
-        subprocess.call(["bin/instance", "stop"])
-
-    __enter__ = start
- 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.stop()
+    return ZopeInstance(tmp_path, pytestconfig)
 
 
 def test(plone_instance):

--- a/collective/searchandreplace/pytests/test_upgrade.py
+++ b/collective/searchandreplace/pytests/test_upgrade.py
@@ -1,0 +1,100 @@
+import sys
+import os
+import time
+import pytest
+import subprocess
+import requests
+import pathlib2 as pathlib
+import socket
+from contextlib import closing
+
+
+def check_socket(host, port):
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        return sock.connect_ex((host, port)) == 0
+
+
+@pytest.fixture
+def plone_instance(tmp_path, pytestconfig):
+    buildout_exe = pathlib.Path(
+        pytestconfig.invocation_dir,
+        sys.argv[0]
+    ).parent.joinpath('buildout')
+    return ZopeInstance(tmp_path, buildout_exe, pytestconfig.rootdir)
+
+
+class ZopeInstance(object):
+
+    def __init__(
+            self,
+            tmp_path,
+            buildout_exe,
+            package_path,
+            host='127.0.0.1',
+            port=8080,
+            ):
+        self.host = host
+        self.port = port
+        buildout_cfg = pathlib.Path(tmp_path, 'buildout.cfg')
+        buildout = u"""
+[buildout]
+extends =  %(package_path)s/buildout.cfg
+develop =  %(package_path)s
+""" % dict(package_path=package_path)
+        with buildout_cfg.open("w") as f:
+            f.write(buildout)
+        os.chdir(str(tmp_path))
+        subprocess.call([str(buildout_exe), "bootstrap"])
+
+        output = subprocess.check_output(
+            ["bin/buildout", "query", "buildout:develop"]
+        )
+        assert str(package_path) in output
+
+        output = subprocess.check_output(
+            ["bin/buildout", "query", "instance:recipe"]
+        )
+        assert 'plone.recipe.zope2instance' in output
+
+        output = subprocess.check_output(
+            ["bin/buildout", "query", "plonesite:recipe"]
+        )
+        assert 'collective.recipe.plonesite' in output
+
+    def run_buildouts(self, from_version):
+        subprocess.call(
+            [
+                "bin/buildout",
+                "buildout:develop=",
+                "versions:%s" % from_version,
+                "install",
+                "instance",
+                "plonesite"
+            ]
+        )
+        assert pathlib.Path("bin/instance").exists()
+        subprocess.call(["bin/buildout", "install", "instance", "plonesite"])
+        assert pathlib.Path("bin/instance").exists()
+
+    def start(self):
+        subprocess.call(["bin/instance", "start"])
+        while not check_socket(self.host, self.port):
+            time.sleep(.3)
+
+    def stop(self):
+        subprocess.call(["bin/instance", "stop"])
+
+    __enter__ = start
+ 
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
+
+def test(plone_instance):
+    plone_instance.run_buildouts("collective.searchandreplace=8.0.0")
+    with plone_instance:
+        r = requests.get(
+            "http://localhost:8080/Plone/@@searchreplace-controlpanel",
+            auth=('admin', 'admin')
+        )
+        assert r.status_code == 200

--- a/collective/searchandreplace/pytests/zope_instance.py
+++ b/collective/searchandreplace/pytests/zope_instance.py
@@ -43,17 +43,17 @@ develop =  %(package_path)s
         output = subprocess.check_output(
             ["bin/buildout", "query", "buildout:develop"]
         )
-        assert str(package_path) in output
+        assert str(package_path).encode('utf8') in output
 
         output = subprocess.check_output(
             ["bin/buildout", "query", "instance:recipe"]
         )
-        assert 'plone.recipe.zope2instance' in output
+        assert b'plone.recipe.zope2instance' in output
 
         output = subprocess.check_output(
             ["bin/buildout", "query", "plonesite:recipe"]
         )
-        assert 'collective.recipe.plonesite' in output
+        assert b'collective.recipe.plonesite' in output
 
     def run_buildouts(self, from_version):
         retcode = subprocess.call(

--- a/collective/searchandreplace/pytests/zope_instance.py
+++ b/collective/searchandreplace/pytests/zope_instance.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import time
+import subprocess
+import pathlib2 as pathlib
+import socket
+from contextlib import closing
+
+
+def check_socket(host, port):
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        return sock.connect_ex((host, port)) == 0
+
+
+class ZopeInstance(object):
+
+    def __init__(
+            self,
+            tmp_path,
+            pytestconfig,
+            host='127.0.0.1',
+            port=8080,
+            ):
+        self.host = host
+        self.port = port
+        buildout_exe = pathlib.Path(
+            pytestconfig.invocation_dir,
+            sys.argv[0]
+        ).parent.joinpath('buildout')
+        package_path = pytestconfig.rootdir
+        buildout_cfg = pathlib.Path(tmp_path, 'buildout.cfg')
+        buildout = u"""
+[buildout]
+extends =  %(package_path)s/buildout.cfg
+develop =  %(package_path)s
+""" % dict(package_path=package_path)
+        with buildout_cfg.open("w") as f:
+            f.write(buildout)
+        os.chdir(str(tmp_path))
+        retcode = subprocess.call([str(buildout_exe), "bootstrap"])
+        assert retcode == 0
+
+        output = subprocess.check_output(
+            ["bin/buildout", "query", "buildout:develop"]
+        )
+        assert str(package_path) in output
+
+        output = subprocess.check_output(
+            ["bin/buildout", "query", "instance:recipe"]
+        )
+        assert 'plone.recipe.zope2instance' in output
+
+        output = subprocess.check_output(
+            ["bin/buildout", "query", "plonesite:recipe"]
+        )
+        assert 'collective.recipe.plonesite' in output
+
+    def run_buildouts(self, from_version):
+        retcode = subprocess.call(
+            [
+                "bin/buildout",
+                "buildout:develop=",
+                "versions:%s" % from_version,
+                "install",
+                "instance",
+                "plonesite"
+            ]
+        )
+        assert retcode == 0
+        assert pathlib.Path("bin/instance").exists()
+        retcode = subprocess.call(["bin/buildout", "install", "instance", "plonesite"])
+        assert retcode == 0
+        assert pathlib.Path("bin/instance").exists()
+
+    def start(self):
+        retcode = subprocess.call(["bin/instance", "start"])
+        assert retcode == 0
+        while not check_socket(self.host, self.port):
+            time.sleep(.3)
+
+    def stop(self):
+        retcode = subprocess.call(["bin/instance", "stop"])
+        assert retcode == 0
+
+    __enter__ = start
+ 
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()

--- a/collective/searchandreplace/searchreplaceutility.py
+++ b/collective/searchandreplace/searchreplaceutility.py
@@ -439,7 +439,7 @@ def getRawTextField(obj, field):
         baseunit = field.getRaw(obj, raw=True)
         if isinstance(baseunit, tuple):
             #  LinesField
-            text = "\n".join(baseunit)
+            text = safe_unicode("\n".join(baseunit))
         elif hasattr(baseunit, 'raw') and isinstance(baseunit.raw, six.text_type):
             text = baseunit.raw
         else:
@@ -450,7 +450,7 @@ def getRawTextField(obj, field):
         if baseunit is None:
             text = u""
         elif isinstance(baseunit, tuple):
-            text = "\n".join(baseunit)
+            text = safe_unicode("\n".join(baseunit))
         else:
             # Rich text has a raw attribute, plain text simply has text
             # (unicode).

--- a/collective/searchandreplace/testing.py
+++ b/collective/searchandreplace/testing.py
@@ -76,6 +76,7 @@ def edit_content(
     plain=None,
     line=None,
     unsearchable=None,
+    subject=None,
 ):
     if MAJOR_PLONE_VERSION >= 5:
         # Dexterity
@@ -93,6 +94,8 @@ def edit_content(
             context.line = line
         if unsearchable is not None:
             context.unsearchable = rich_text(unsearchable)
+        if subject is not None:
+            context.subject = subject
     else:
         # Archetypes
         if title is not None:
@@ -109,4 +112,6 @@ def edit_content(
             context.setLine(line)
         if unsearchable is not None:
             context.setUnsearchable(unsearchable)
+        if subject is not None:
+            context.setSubject(subject)
     context.reindexObject()

--- a/collective/searchandreplace/tests/test_matchcase.py
+++ b/collective/searchandreplace/tests/test_matchcase.py
@@ -21,33 +21,33 @@ class TestMatchCase(unittest.TestCase):
 
     def testNoMatchCase(self):
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
-        create_doc(self.portal, id="doc1", title=u"Test Title", text=u"Test Case")
+        create_doc(self.portal, id="doc1", title=u"Find Title", text=u"Find Case")
         doc1 = getattr(self.portal, "doc1")
-        results = self.srutil.findObjects(doc1, "test case", matchCase=False)
+        results = self.srutil.findObjects(doc1, "find case", matchCase=False)
         self.assertEqual(len(results), 1)
 
     def testMatchCase(self):
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         self.portal.invokeFactory("Document", "doc2")
         doc2 = getattr(self.portal, "doc2")
-        edit_content(doc2, title="test title", text="Test Case")
-        results = self.srutil.findObjects(doc2, "test case", matchCase=True)
+        edit_content(doc2, title="find title", text="Find Case")
+        results = self.srutil.findObjects(doc2, "find case", matchCase=True)
         self.assertEqual(len(results), 0)
 
     def testOneMatch(self):
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         self.portal.invokeFactory("Document", "doc1")
         doc1 = getattr(self.portal, "doc1")
-        edit_content(doc1, title="Test Title", text="Test Case")
+        edit_content(doc1, title="Find Title", text="Find Case")
         self.portal.invokeFactory("Document", "doc2")
         doc2 = getattr(self.portal, "doc2")
-        edit_content(doc2, title="test title", text="test case")
+        edit_content(doc2, title="find title", text="find case")
         # path1 = '%s' %  '/'.join(doc1.getPhysicalPath())
         # path2 = '%s' % '/'.join(doc2.getPhysicalPath())
         # paths = {path1: {'body': [0]}, path2: {'body': [0]}}
         results = self.srutil.findObjects(
             self.portal,
-            "test case",
+            "find case",
             matchCase=True,
             # occurences=paths
         )
@@ -66,11 +66,11 @@ class TestMultipleMatchCase(unittest.TestCase):
         self.portal.invokeFactory("Document", "doc1")
         self.doc1 = getattr(self.portal, "doc1")
         edit_content(
-            self.doc1, title="Test test Test test", text="Test test\nTest test"
+            self.doc1, title="Find find Find find", text="Find find\nFind find"
         )
 
     def testSearchCase(self):
-        results = self.srutil.findObjects(self.portal, "Test", matchCase=True,)
+        results = self.srutil.findObjects(self.portal, "Find", matchCase=True,)
         self.assertEqual(len(results), 4)
         # title field, first match
         self.assertEqual(results[0]["linecol"], "Title")
@@ -96,18 +96,18 @@ class TestMultipleMatchCase(unittest.TestCase):
         self.assertEqual(results[3]["pos"], "10")
 
     def testSearchNoCase(self):
-        results = self.srutil.findObjects(self.portal, "Test", matchCase=False,)
+        results = self.srutil.findObjects(self.portal, "Find", matchCase=False,)
         self.assertEqual(len(results), 8)
 
     def testReplaceAll(self):
         from collective.searchandreplace.searchreplaceutility import getRawText
 
         results = self.srutil.replaceAllMatches(
-            self.portal, "Test", replaceWith="Bike", matchCase=True,
+            self.portal, "Find", replaceWith="Bike", matchCase=True,
         )
         self.assertEqual(results, 4)
-        self.assertEqual(self.doc1.Title(), "Bike test Bike test")
-        self.assertEqual(getRawText(self.doc1), "Bike test\nBike test")
+        self.assertEqual(self.doc1.Title(), "Bike find Bike find")
+        self.assertEqual(getRawText(self.doc1), "Bike find\nBike find")
 
     def testReplacePaths(self):
         from collective.searchandreplace.searchreplaceutility import getRawText
@@ -122,8 +122,8 @@ class TestMultipleMatchCase(unittest.TestCase):
             }
         }
         results = self.srutil.replaceFilteredOccurences(
-            self.portal, "Test", replaceWith="Bike", occurences=paths, matchCase=False,
+            self.portal, "Find", replaceWith="Bike", occurences=paths, matchCase=False,
         )
         self.assertEqual(results, 4)
-        self.assertEqual(self.doc1.Title(), "Bike test Bike test")
-        self.assertEqual(getRawText(self.doc1), "Test Bike\nTest Bike")
+        self.assertEqual(self.doc1.Title(), "Bike find Bike find")
+        self.assertEqual(getRawText(self.doc1), "Find Bike\nFind Bike")

--- a/collective/searchandreplace/tests/test_replacewhere.py
+++ b/collective/searchandreplace/tests/test_replacewhere.py
@@ -31,23 +31,23 @@ class TestReplaceWhere(unittest.TestCase):
         self.portal.invokeFactory("Document", "doc1")
         doc1 = getattr(self.portal, "doc1")
         edit_content(
-            doc1, title="Test Title", description="Test Description", text="Test Case"
+            doc1, title="Find Title", description="Find Description", text="Find Case"
         )
-        self.assertEqual(getRawText(doc1), "Test Case")
+        self.assertEqual(getRawText(doc1), "Find Case")
         # Search it.
-        parameters = dict(context=doc1, findWhat="test case", matchCase=False)
+        parameters = dict(context=doc1, findWhat="find case", matchCase=False)
         results = self.srutil.findObjects(**parameters)
         self.assertEqual(len(results), 1)
-        self.assertEqual(getRawText(doc1), "Test Case")
-        r_parameters = dict(replaceWith="foo",)
+        self.assertEqual(getRawText(doc1), "Find Case")
+        r_parameters = dict(replaceWith="replaced",)
         r_parameters.update(parameters)
         results = self.srutil.replaceAllMatches(**r_parameters)
         # Note: replacing returns an int, not a list.
         self.assertEqual(results, 1)
-        self.assertEqual(getRawText(doc1), "foo")
+        self.assertEqual(getRawText(doc1), "replaced")
         # Other fields are not changed.
-        self.assertEqual(doc1.Title(), "Test Title")
-        self.assertEqual(doc1.Description(), "Test Description")
+        self.assertEqual(doc1.Title(), "Find Title")
+        self.assertEqual(doc1.Description(), "Find Description")
 
     def testReplaceTitle(self):
         from collective.searchandreplace.searchreplaceutility import getRawText
@@ -56,22 +56,22 @@ class TestReplaceWhere(unittest.TestCase):
         self.portal.invokeFactory("Document", "doc2")
         doc1 = getattr(self.portal, "doc2")
         edit_content(
-            doc1, title="Test Title", description="Test Description", text="Test Case"
+            doc1, title="Find Title", description="Find Description", text="Find Case"
         )
-        self.assertEqual(doc1.Title(), "Test Title")
+        self.assertEqual(doc1.Title(), "Find Title")
         # Search it.
-        parameters = dict(context=doc1, findWhat="test title", matchCase=False)
+        parameters = dict(context=doc1, findWhat="find title", matchCase=False)
         results = self.srutil.findObjects(**parameters)
         self.assertEqual(len(results), 1)
-        self.assertEqual(doc1.Title(), "Test Title")
-        r_parameters = dict(replaceWith="foo",)
+        self.assertEqual(doc1.Title(), "Find Title")
+        r_parameters = dict(replaceWith="replaced",)
         r_parameters.update(parameters)
         results = self.srutil.replaceAllMatches(**r_parameters)
         self.assertEqual(results, 1)
-        self.assertEqual(doc1.Title(), "foo")
+        self.assertEqual(doc1.Title(), "replaced")
         # Other fields are not changed.
-        self.assertEqual(doc1.Description(), "Test Description")
-        self.assertEqual(getRawText(doc1), "Test Case")
+        self.assertEqual(doc1.Description(), "Find Description")
+        self.assertEqual(getRawText(doc1), "Find Case")
 
     def testReplaceDescription(self):
         from collective.searchandreplace.searchreplaceutility import getRawText
@@ -80,25 +80,25 @@ class TestReplaceWhere(unittest.TestCase):
         self.portal.invokeFactory("Document", "doc1")
         doc1 = getattr(self.portal, "doc1")
         edit_content(
-            doc1, title="Test Title", description="Test Description", text="Test Case"
+            doc1, title="Find Title", description="Find Description", text="Find Case"
         )
-        self.assertEqual(doc1.Description(), "Test Description")
+        self.assertEqual(doc1.Description(), "Find Description")
         # Search it.
-        parameters = dict(context=doc1, findWhat="test desc", matchCase=False)
+        parameters = dict(context=doc1, findWhat="find desc", matchCase=False)
         results = self.srutil.findObjects(**parameters)
         self.assertEqual(len(results), 1)
-        self.assertEqual(doc1.Description(), "Test Description")
+        self.assertEqual(doc1.Description(), "Find Description")
 
-        r_parameters = dict(replaceWith="foo",)
+        r_parameters = dict(replaceWith="replaced",)
         r_parameters.update(parameters)
         results = self.srutil.replaceAllMatches(**r_parameters)
         self.assertEqual(results, 1)
         # Note: we have replaced only part of the description.
-        self.assertEqual(doc1.Description(), "fooription")
+        self.assertEqual(doc1.Description(), "replacedription")
 
         # Other fields are not changed.
-        self.assertEqual(doc1.Title(), "Test Title")
-        self.assertEqual(getRawText(doc1), "Test Case")
+        self.assertEqual(doc1.Title(), "Find Title")
+        self.assertEqual(getRawText(doc1), "Find Case")
 
     def testReplaceOnlyEditableContent(self):
         # setRoles(self.portal, TEST_USER_ID, ['Manager'])
@@ -106,22 +106,22 @@ class TestReplaceWhere(unittest.TestCase):
         # /mainfolder
         self.portal.invokeFactory("Folder", "mainfolder")
         mainfolder = getattr(self.portal, "mainfolder")
-        edit_content(mainfolder, title="Test Title")
+        edit_content(mainfolder, title="Find Title")
 
         # /mainfolder/maindoc
         mainfolder.invokeFactory("Document", "maindoc")
         maindoc = getattr(mainfolder, "maindoc")
-        edit_content(maindoc, title="Test Title")
+        edit_content(maindoc, title="Find Title")
 
         # /mainfolder/subfolder
         mainfolder.invokeFactory("Folder", "subfolder")
         subfolder = getattr(mainfolder, "subfolder")
-        edit_content(subfolder, title="Test Title")
+        edit_content(subfolder, title="Find Title")
 
         # /mainfolder/subfolder/subdoc
         subfolder.invokeFactory("Document", "subdoc")
         subdoc = getattr(subfolder, "subdoc")
-        edit_content(subdoc, title="Test Title")
+        edit_content(subdoc, title="Find Title")
 
         # Give test user a local Editor role on the sub folder.
         subfolder.manage_addLocalRoles(TEST_USER_ID, ("Editor",))
@@ -132,14 +132,14 @@ class TestReplaceWhere(unittest.TestCase):
         self.portal.portal_catalog.reindexObject(subdoc)
 
         # We are logged in as portal owner, so we can edit everything.
-        results = self.srutil.findObjects(mainfolder, "test title", matchCase=False)
+        results = self.srutil.findObjects(mainfolder, "find title", matchCase=False)
         self.assertEqual(len(results), 4)
 
         # Login as the test user again.
         logout()
         login(self.portal, TEST_USER_NAME)
         # Now we can edit less: only the sub folder and sub doc.
-        parameters = dict(context=mainfolder, findWhat="test title", matchCase=False)
+        parameters = dict(context=mainfolder, findWhat="find title", matchCase=False)
         results = self.srutil.findObjects(**parameters)
         self.assertEqual(len(results), 2)
         paths = [x["path"] for x in results]
@@ -149,19 +149,19 @@ class TestReplaceWhere(unittest.TestCase):
         self.assertNotIn("/".join(maindoc.getPhysicalPath()), paths)
 
         # Nothing has been changed, because we were only searching.
-        self.assertEqual(mainfolder.Title(), "Test Title")
-        self.assertEqual(maindoc.Title(), "Test Title")
-        self.assertEqual(subfolder.Title(), "Test Title")
-        self.assertEqual(subfolder.Title(), "Test Title")
+        self.assertEqual(mainfolder.Title(), "Find Title")
+        self.assertEqual(maindoc.Title(), "Find Title")
+        self.assertEqual(subfolder.Title(), "Find Title")
+        self.assertEqual(subfolder.Title(), "Find Title")
 
-        r_parameters = dict(replaceWith="foo",)
+        r_parameters = dict(replaceWith="replaced",)
         r_parameters.update(parameters)
         results = self.srutil.replaceAllMatches(**r_parameters)
         self.assertEqual(results, 2)
-        self.assertEqual(mainfolder.Title(), "Test Title")
-        self.assertEqual(maindoc.Title(), "Test Title")
-        self.assertEqual(subfolder.Title(), "foo")
-        self.assertEqual(subfolder.Title(), "foo")
+        self.assertEqual(mainfolder.Title(), "Find Title")
+        self.assertEqual(maindoc.Title(), "Find Title")
+        self.assertEqual(subfolder.Title(), "replaced")
+        self.assertEqual(subfolder.Title(), "replaced")
 
     def testReplaceTextFieldsButNotTextlineFields(self):
         from collective.searchandreplace.searchreplaceutility import getRawText
@@ -178,34 +178,34 @@ class TestReplaceWhere(unittest.TestCase):
         doc1 = getattr(self.portal, "doc1")
         edit_content(
             doc1,
-            title="Test Title",
-            description="Test Description",
-            rich="Test Rich",
-            plain="Test Plain",
-            line="Test Line",
-            unsearchable="Test Unsearchable",
+            title="Find Title",
+            description="Find Description",
+            rich="Find Rich",
+            plain="Find Plain",
+            line="Find Line",
+            unsearchable="Find Unsearchable",
         )
 
         # Test the initial values.
-        self.assertEqual(doc1.Title(), "Test Title")
-        self.assertEqual(doc1.Description(), "Test Description")
-        self.assertEqual(getRawText(doc1, "rich"), "Test Rich")
-        self.assertEqual(getRawText(doc1, "plain"), "Test Plain")
-        self.assertEqual(getRawText(doc1, "line"), "Test Line")
-        self.assertEqual(getRawText(doc1, "unsearchable"), "Test Unsearchable")
+        self.assertEqual(doc1.Title(), "Find Title")
+        self.assertEqual(doc1.Description(), "Find Description")
+        self.assertEqual(getRawText(doc1, "rich"), "Find Rich")
+        self.assertEqual(getRawText(doc1, "plain"), "Find Plain")
+        self.assertEqual(getRawText(doc1, "line"), "Find Line")
+        self.assertEqual(getRawText(doc1, "unsearchable"), "Find Unsearchable")
 
         # Search it.
-        parameters = dict(context=doc1, findWhat="Test", matchCase=False)
+        parameters = dict(context=doc1, findWhat="Find", matchCase=False)
         results = self.srutil.findObjects(**parameters)
         self.assertEqual(len(results), 5)
 
         # Nothing should have changed.
-        self.assertEqual(doc1.Title(), "Test Title")
-        self.assertEqual(doc1.Description(), "Test Description")
-        self.assertEqual(getRawText(doc1, "rich"), "Test Rich")
-        self.assertEqual(getRawText(doc1, "plain"), "Test Plain")
-        self.assertEqual(getRawText(doc1, "line"), "Test Line")
-        self.assertEqual(getRawText(doc1, "unsearchable"), "Test Unsearchable")
+        self.assertEqual(doc1.Title(), "Find Title")
+        self.assertEqual(doc1.Description(), "Find Description")
+        self.assertEqual(getRawText(doc1, "rich"), "Find Rich")
+        self.assertEqual(getRawText(doc1, "plain"), "Find Plain")
+        self.assertEqual(getRawText(doc1, "line"), "Find Line")
+        self.assertEqual(getRawText(doc1, "unsearchable"), "Find Unsearchable")
 
         r_parameters = dict(replaceWith="Foo",)
         r_parameters.update(parameters)
@@ -220,7 +220,7 @@ class TestReplaceWhere(unittest.TestCase):
         self.assertEqual(getRawText(doc1, "unsearchable"), "Foo Unsearchable")
 
         # But not the textline field.
-        self.assertEqual(getRawText(doc1, "line"), "Test Line")
+        self.assertEqual(getRawText(doc1, "line"), "Find Line")
 
     def testReplaceAllFields(self):
         from collective.searchandreplace.searchreplaceutility import getRawText
@@ -233,34 +233,34 @@ class TestReplaceWhere(unittest.TestCase):
         doc1 = getattr(self.portal, "doc1")
         edit_content(
             doc1,
-            title="Test Title",
-            description="Test Description",
-            rich="Test Rich",
-            plain="Test Plain",
-            line="Test Line",
-            unsearchable="Test Unsearchable",
+            title="Find Title",
+            description="Find Description",
+            rich="Find Rich",
+            plain="Find Plain",
+            line="Find Line",
+            unsearchable="Find Unsearchable",
         )
 
         # Test the initial values.
-        self.assertEqual(doc1.Title(), "Test Title")
-        self.assertEqual(doc1.Description(), "Test Description")
-        self.assertEqual(getRawText(doc1, "rich"), "Test Rich")
-        self.assertEqual(getRawText(doc1, "plain"), "Test Plain")
-        self.assertEqual(getRawText(doc1, "line"), "Test Line")
-        self.assertEqual(getRawText(doc1, "unsearchable"), "Test Unsearchable")
+        self.assertEqual(doc1.Title(), "Find Title")
+        self.assertEqual(doc1.Description(), "Find Description")
+        self.assertEqual(getRawText(doc1, "rich"), "Find Rich")
+        self.assertEqual(getRawText(doc1, "plain"), "Find Plain")
+        self.assertEqual(getRawText(doc1, "line"), "Find Line")
+        self.assertEqual(getRawText(doc1, "unsearchable"), "Find Unsearchable")
 
         # Search it.
-        parameters = dict(context=doc1, findWhat="Test", matchCase=False)
+        parameters = dict(context=doc1, findWhat="Find", matchCase=False)
         results = self.srutil.findObjects(**parameters)
         self.assertEqual(len(results), 6)
 
         # Nothing should have changed.
-        self.assertEqual(doc1.Title(), "Test Title")
-        self.assertEqual(doc1.Description(), "Test Description")
-        self.assertEqual(getRawText(doc1, "rich"), "Test Rich")
-        self.assertEqual(getRawText(doc1, "plain"), "Test Plain")
-        self.assertEqual(getRawText(doc1, "line"), "Test Line")
-        self.assertEqual(getRawText(doc1, "unsearchable"), "Test Unsearchable")
+        self.assertEqual(doc1.Title(), "Find Title")
+        self.assertEqual(doc1.Description(), "Find Description")
+        self.assertEqual(getRawText(doc1, "rich"), "Find Rich")
+        self.assertEqual(getRawText(doc1, "plain"), "Find Plain")
+        self.assertEqual(getRawText(doc1, "line"), "Find Line")
+        self.assertEqual(getRawText(doc1, "unsearchable"), "Find Unsearchable")
 
         r_parameters = dict(replaceWith="Foo",)
         r_parameters.update(parameters)
@@ -287,12 +287,12 @@ class TestReplaceWhere(unittest.TestCase):
         self.portal.invokeFactory("SampleType", "doc1")
         doc1 = getattr(self.portal, "doc1")
         edit_content(
-            doc1, title="Test Title", unsearchable="Test Unsearchable",
+            doc1, title="Find Title", unsearchable="Find Unsearchable",
         )
 
         # Test the initial values.
-        self.assertEqual(doc1.Title(), "Test Title")
-        self.assertEqual(getRawText(doc1, "unsearchable"), "Test Unsearchable")
+        self.assertEqual(doc1.Title(), "Find Title")
+        self.assertEqual(getRawText(doc1, "unsearchable"), "Find Unsearchable")
 
         # Search it with onlySearchableText true.
         parameters = dict(
@@ -311,7 +311,7 @@ class TestReplaceWhere(unittest.TestCase):
         self.assertEqual(results, 0)
 
         # Nothing should have changed.
-        self.assertEqual(getRawText(doc1, "unsearchable"), "Test Unsearchable")
+        self.assertEqual(getRawText(doc1, "unsearchable"), "Find Unsearchable")
 
         # Now search everything, so onlySearchableText false.
         parameters["onlySearchableText"] = False
@@ -319,13 +319,13 @@ class TestReplaceWhere(unittest.TestCase):
         self.assertEqual(len(results), 1)
 
         # Nothing should have changed.
-        self.assertEqual(getRawText(doc1, "unsearchable"), "Test Unsearchable")
+        self.assertEqual(getRawText(doc1, "unsearchable"), "Find Unsearchable")
 
         # Replace it.
         r_parameters["onlySearchableText"] = False
         results = self.srutil.replaceAllMatches(**r_parameters)
         self.assertEqual(results, 1)
-        self.assertEqual(getRawText(doc1, "unsearchable"), "Test Foo")
+        self.assertEqual(getRawText(doc1, "unsearchable"), "Find Foo")
 
     def testReplaceRawHTML(self):
         from collective.searchandreplace.searchreplaceutility import getRawText
@@ -333,7 +333,7 @@ class TestReplaceWhere(unittest.TestCase):
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         self.portal.invokeFactory("Document", "doc1")
         doc1 = getattr(self.portal, "doc1")
-        edit_content(doc1, title="Test Title", text="My <strong>Test</strong> Case")
+        edit_content(doc1, title="Find Title", text="My <strong>Test</strong> Case")
         self.assertEqual(getRawText(doc1), "My <strong>Test</strong> Case")
 
         # Search only in SearchableText.
@@ -360,6 +360,110 @@ class TestReplaceWhere(unittest.TestCase):
         self.assertEqual(results, 1)
         self.assertEqual(getRawText(doc1), "My <em>Test</em> Case")
 
+    def testDoNotFindSubject(self):
+        from collective.searchandreplace.searchreplaceutility import getRawText
+
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Document", "doc1")
+        doc1 = getattr(self.portal, "doc1")
+        edit_content(
+            doc1, title="Find Title", subject=("Find subject", "Replace")
+        )
+        self.assertEqual(doc1.Subject(), ("Find subject", "Replace"))
+        # Search it.
+        parameters = dict(context=doc1, findWhat="find subject", matchCase=False,
+            onlySearchableText=True
+        )
+        results = self.srutil.findObjects(**parameters)
+        self.assertEqual(len(results), 0)
+
+    def testReplaceSubject(self):
+        from collective.searchandreplace.searchreplaceutility import getRawText
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISearchReplaceSettings, check=False)
+        settings.include_lines_fields = True
+
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Document", "doc1")
+        doc1 = getattr(self.portal, "doc1")
+        edit_content(
+            doc1, title="Find Title", subject=("Find subject", "Replace")
+        )
+        self.assertEqual(doc1.Subject(), ("Find subject", "Replace"))
+        # Search it.
+        parameters = dict(context=doc1, findWhat="find subject", matchCase=False,
+            onlySearchableText=True
+        )
+        results = self.srutil.findObjects(**parameters)
+        self.assertEqual(len(results), 1)
+        r_parameters = dict(replaceWith="replaced",)
+        r_parameters.update(parameters)
+        results = self.srutil.replaceAllMatches(**r_parameters)
+        # Note: replacing returns an int, not a list.
+        self.assertEqual(results, 1)
+        self.assertEqual(doc1.Subject(), ("replaced", "Replace"))
+        # Other fields are not changed.
+        self.assertEqual(doc1.Title(), "Find Title")
+
+    def testReplaceSubjectSecondItem(self):
+        from collective.searchandreplace.searchreplaceutility import getRawText
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISearchReplaceSettings, check=False)
+        settings.include_lines_fields = True
+
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Document", "doc1")
+        doc1 = getattr(self.portal, "doc1")
+        edit_content(
+            doc1, title="Find Title", subject=("Replace", "Find subject", "Replace")
+        )
+        self.assertEqual(doc1.Subject(), ("Replace", "Find subject", "Replace"))
+        # Search it.
+        parameters = dict(context=doc1, findWhat="find subject", matchCase=False,
+            onlySearchableText=True
+        )
+        results = self.srutil.findObjects(**parameters)
+        self.assertEqual(len(results), 1)
+        r_parameters = dict(replaceWith="replaced",)
+        r_parameters.update(parameters)
+        results = self.srutil.replaceAllMatches(**r_parameters)
+        # Note: replacing returns an int, not a list.
+        self.assertEqual(results, 1)
+        self.assertEqual(doc1.Subject(), ("Replace", "replaced", "Replace"))
+        # Other fields are not changed.
+        self.assertEqual(doc1.Title(), "Find Title")
+
+    def testReplaceSubjectTwiceInThirdItem(self):
+        from collective.searchandreplace.searchreplaceutility import getRawText
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISearchReplaceSettings, check=False)
+        settings.include_lines_fields = True
+
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Document", "doc1")
+        doc1 = getattr(self.portal, "doc1")
+        edit_content(
+            doc1, title="Find Title", subject=("Replace", "Replace", "Find subject find subject")
+        )
+        self.assertEqual(doc1.Subject(), ("Replace", "Replace", "Find subject find subject"))
+        # Search it.
+        parameters = dict(context=doc1, findWhat="find subject", matchCase=False,
+            onlySearchableText=True
+        )
+        results = self.srutil.findObjects(**parameters)
+        self.assertEqual(len(results), 2)
+        r_parameters = dict(replaceWith="replaced",)
+        r_parameters.update(parameters)
+        results = self.srutil.replaceAllMatches(**r_parameters)
+        # Note: replacing returns an int, not a list.
+        self.assertEqual(results, 2)
+        self.assertEqual(doc1.Subject(), ("Replace", "Replace", "replaced replaced"))
+        # Other fields are not changed.
+        self.assertEqual(doc1.Title(), "Find Title")
+
 
 class TestModified(unittest.TestCase):
     """Test update_modified setting"""
@@ -373,7 +477,7 @@ class TestModified(unittest.TestCase):
         self.portal.invokeFactory("Document", "doc1")
         doc1 = getattr(self.portal, "doc1")
         edit_content(
-            doc1, title="Test Title", description="Test Description", text="Test Case"
+            doc1, title="Find Title", description="Find Description", text="Find Case"
         )
         # when an object has never been saved to repository
         # any call to save to repository, like in _afterReplace,
@@ -402,14 +506,14 @@ class TestModified(unittest.TestCase):
         from collective.searchandreplace.searchreplaceutility import getRawText
 
         doc1 = getattr(self.portal, "doc1")
-        self.assertEqual(getRawText(doc1), "Test Case")
+        self.assertEqual(getRawText(doc1), "Find Case")
         # Replace it after 1 second to ensure different modified date
         import time
 
         time.sleep(1)
         replace_parameters = dict(
-            context=doc1, findWhat="test case", replaceWith="foo", matchCase=False
+            context=doc1, findWhat="find case", replaceWith="replaced", matchCase=False
         )
         results = self.srutil.replaceAllMatches(**replace_parameters)
         self.assertEqual(results, 1)
-        self.assertEqual(getRawText(doc1), "foo")
+        self.assertEqual(getRawText(doc1), "replaced")

--- a/collective/searchandreplace/tests/test_replacewhere.py
+++ b/collective/searchandreplace/tests/test_replacewhere.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from collective.searchandreplace.interfaces import ISearchReplaceUtility
 from collective.searchandreplace.interfaces import ISearchReplaceSettings
 from collective.searchandreplace.testing import edit_content
@@ -11,6 +12,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
+import six
 
 import unittest
 
@@ -503,11 +505,14 @@ class TestReplaceWhere(unittest.TestCase):
         )
         results = self.srutil.findObjects(**parameters)
         self.assertEqual(len(results), 1)
-        r_parameters = dict(replaceWith="Remplac\xc3\xa9".decode('utf8'),)
+        r_parameters = dict(replaceWith=u"Remplacé",)
         r_parameters.update(parameters)
         results = self.srutil.replaceAllMatches(**r_parameters)
         self.assertEqual(results, 1)
-        self.assertEqual(doc1.Subject(), ("Remplac\xc3\xa9", "Replaced"))
+        if six.PY3:
+            self.assertEqual(doc1.Subject(), (u"Remplacé", "Replaced"))
+        if six.PY2:
+            self.assertEqual(doc1.Subject(), (u"Remplacé".encode('utf8'), "Replaced"))
 
 class TestModified(unittest.TestCase):
     """Test update_modified setting"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 ignore =
     *.cfg
     .travis.yml
+
+[tool:pytest]
+addopts = --disable-warnings --pyargs collective.searchandreplace

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,16 @@ setup(
         "zope.schema",
         "plone.api",
     ],
-    extras_require={"test": ["collective.dexteritytextindexer", "plone.app.testing",],},
+    extras_require=dict(
+        test=[
+           "collective.dexteritytextindexer",
+           "plone.app.testing",
+        ],
+        pytest=[
+           'pytest',
+           'gocept.pytestlayer',
+        ],
+    ),
     entry_points="""
     # -*- Entry points: -*-
     [z3c.autoinclude.plugin]

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,8 @@ setup(
         pytest=[
            'pytest',
            'gocept.pytestlayer',
+           'pathlib2',
+           'requests',
         ],
     ),
     entry_points="""


### PR DESCRIPTION
Archetypes ``ILinesField``
Dexterity ``ITuple`` with ``value_type==ITextLine``

Can be enabled with registry ``include_lines_fields`` to True