### PR TITLE
add info for endusers to show where search and replace will happen

### DIFF
--- a/collective/searchandreplace/browser/pageform.pt
+++ b/collective/searchandreplace/browser/pageform.pt
@@ -40,7 +40,18 @@
             Search and replace
           </h1>
 
-          <div class="documentDescription" tal:content="view/description|nothing">Description</div>
+          <h2>
+            <span i18n:translate="">in</span>
+            <span tal:replace="context/Title">Title</span>
+            (<span tal:replace="context/portal_type">Item type</span>)
+          </h2>
+
+          <div
+            class="documentDescription"
+            tal:content="view/description|nothing"
+          >
+            Description
+          </div>
 
           <div id="content-core">
             <p


### PR DESCRIPTION
- the UI did not yet show an indication to the end user as to where (in which page, folder, ...) they are searching and replacing
- we might need to add translation or adjust the info message to make it more clear

- note: this was based on the cleanup branch (PR https://github.com/collective/collective.searchandreplace/pull/44 )