### PR TITLE
Fix empty replace

### DIFF
--- a/collective/searchandreplace/searchreplaceutility.py
+++ b/collective/searchandreplace/searchreplaceutility.py
@@ -287,6 +287,8 @@ def reindexObject(obj):
 def replaceText(matcher, text, rtext, indexes):
     """ Replace instances """
     newtext = ""
+    if not rtext:
+        rtext = ""
     mindex = 0
     repl_count = 0
     mobj = matcher.finditer(text)

--- a/collective/searchandreplace/tests/test_replacewhere.py
+++ b/collective/searchandreplace/tests/test_replacewhere.py
@@ -553,6 +553,35 @@ class TestReplaceWhere(unittest.TestCase):
         if six.PY2:
             self.assertEqual(doc1.Subject(), (u"Remplacé".encode("utf8"), "Replaced"))
 
+    def testReplaceEmpty(self):
+        from collective.searchandreplace.searchreplaceutility import getRawText
+
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Document", "doc1")
+        doc1 = getattr(self.portal, "doc1")
+        edit_content(
+            doc1,
+            title="Find My Title",
+            description="Find My Description",
+            text="Find My Text",
+        )
+        self.assertEqual(getRawText(doc1), "Find My Text")
+        # Search it.
+        parameters = dict(context=doc1, findWhat=" My", matchCase=False)
+        results = self.srutil.findObjects(**parameters)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(getRawText(doc1), "Find My Text")
+        r_parameters = dict(
+            replaceWith="",
+        )
+        r_parameters.update(parameters)
+        results = self.srutil.replaceAllMatches(**r_parameters)
+        # Note: replacing returns an int, not a list.
+        self.assertEqual(results, 3)
+        self.assertEqual(getRawText(doc1), "Find Text")
+        self.assertEqual(doc1.Title(), "Find Title")
+        self.assertEqual(doc1.Description(), "Find Description")
+
 
 class TestModified(unittest.TestCase):
     """Test update_modified setting"""


### PR DESCRIPTION
- fix error when leaving the 'replace what' field empty (see https://github.com/collective/collective.searchandreplace/issues/43)
- added test to check that it does not fail when leaving replace field empty
- note that this will empower users to remove parts of the text using the search and replace functionality, which for us is a valid usecase, but could be discussed

- note: this was based on the cleanup branch (PR https://github.com/collective/collective.searchandreplace/pull/44 )