### PR TITLE
Fix empty find what

### DIFF
--- a/collective/searchandreplace/browser/searchreplacetable.py
+++ b/collective/searchandreplace/browser/searchreplacetable.py
@@ -16,6 +16,7 @@ class SearchReplaceTable(BrowserView):
 
     def getItems(self):
         """ Get preview items """
+        results = []
         findWhat = self.request.get("form.findWhat", "")
         searchSubFolders = "form.searchSubfolders" in self.request
         matchCase = "form.matchCase" in self.request
@@ -26,14 +27,15 @@ class SearchReplaceTable(BrowserView):
         onlySearchableText = "form.onlySearchableText" in self.request
 
         srutil = getUtility(ISearchReplaceUtility)
-        results = srutil.findObjects(
-            self.context,
-            findWhat=findWhat,
-            searchSubFolders=searchSubFolders,
-            matchCase=matchCase,
-            maxResults=maxResults,
-            onlySearchableText=onlySearchableText,
-        )
+        if findWhat:
+            results = srutil.findObjects(
+                self.context,
+                findWhat=findWhat,
+                searchSubFolders=searchSubFolders,
+                matchCase=matchCase,
+                maxResults=maxResults,
+                onlySearchableText=onlySearchableText,
+            )
         return results
 
     def getRelativePath(self, path):


### PR DESCRIPTION
- fix error when leaving the 'find what' field empty (see https://github.com/collective/collective.searchandreplace/issues/43) 
- when leaving the 'find what' field empty, it will now show the validation error (red border and mention field is required) on the field which it did not before
- no test added yet, still have to figure out where best to test triggering the validation

- note: this was based on the cleanup branch (PR https://github.com/collective/collective.searchandreplace/pull/44 )