### PR TITLE
Fix Travis builds on Python 2.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -34,6 +34,10 @@ zodbupdate = 0.5
 collective.upgrade = 1.6
 zodbupdate = 1.4
 
+[versions:python2]
+check-manifest = 0.41
+virtualenv = <=20
+
 [instance]
 eggs += collective.upgrade
 


### PR DESCRIPTION
Plone 4.3 and 5.1 fail for recent PR jobs.
See https://travis-ci.org/github/collective/collective.searchandreplace/builds/750732175

```
Version and requirements information containing distlib:
1834  [versions] constraint on distlib: 0.3.0
1835  Requirement of virtualenv>=20.0.35: distlib<1,>=0.3.1
1836While:
1837  Installing.
1838  Getting section code-analysis.
1839  Initializing section code-analysis.
1840  Installing recipe plone.recipe.codeanalysis.
1841Error: The requirement ('distlib<1,>=0.3.1') is not allowed by your [versions] constraint (0.3.0)
```

The real problem here is that we get `check-manifest` 0.42 or higher, which only works on Python 3.