### PR TITLE
Replace button is available without preview

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 8.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not show "Replace" button until user has seen Preview results.
+  [gotcha]
 
 
 8.1.1 (2021-01-11)

--- a/collective/searchandreplace/browser/searchreplaceform.py
+++ b/collective/searchandreplace/browser/searchreplaceform.py
@@ -105,7 +105,14 @@ class SearchReplaceForm(AddForm):
         """ Preview files to be changed. """
         self.form_reset = False
 
-    @action(_(u"Replace"), validator=validate_searchreplaceform, name=u"Replace")
+    def show_replace(self, action):
+        return ('form.actions.Preview' in self.request.form
+                or
+                'form.actions.Replace' in self.request.form
+                )
+
+    @action(_(u"Replace"), validator=validate_searchreplaceform,
+            name=u"Replace", condition="show_replace")
     def action_replace(self, action, data):
         """ Replace text for all files. """
         self.form_reset = False

--- a/collective/searchandreplace/browser/searchreplaceform.py
+++ b/collective/searchandreplace/browser/searchreplaceform.py
@@ -39,9 +39,9 @@ class ISearchReplaceForm(Interface):
         title=_(u"Maximum Number of Results"),
         description=_(
             u"Maximum number of results to show. "
-            "Warning: this has no effect on how many found texts are "
-            "replaced when you use the Replace button directly without "
-            "using the Preview."
+            "Warning: this only affects how many preview results are shown. "
+            "It has no effect on how many found texts are "
+            "replaced when you use the Replace button."
         ),
         default=None,
         required=False,
@@ -106,13 +106,17 @@ class SearchReplaceForm(AddForm):
         self.form_reset = False
 
     def show_replace(self, action):
-        return ('form.actions.Preview' in self.request.form
-                or
-                'form.actions.Replace' in self.request.form
-                )
+        return (
+            "form.actions.Preview" in self.request.form
+            or "form.actions.Replace" in self.request.form
+        )
 
-    @action(_(u"Replace"), validator=validate_searchreplaceform,
-            name=u"Replace", condition="show_replace")
+    @action(
+        _(u"Replace"),
+        validator=validate_searchreplaceform,
+        name=u"Replace",
+        condition="show_replace",
+    )
     def action_replace(self, action, data):
         """ Replace text for all files. """
         self.form_reset = False

--- a/collective/searchandreplace/locales/SearchAndReplace.pot
+++ b/collective/searchandreplace/locales/SearchAndReplace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,43 +17,55 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: SearchAndReplace\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:48
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -61,67 +73,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -150,19 +170,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -171,6 +195,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/af/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/af/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: af\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/ar/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/ar/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: ar\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/bn/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/bn/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: bn\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/ca/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/ca/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: ca\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/de/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/de/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: de\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/en/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/en/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: en\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/es/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/es/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2012-08-07 21:39+0100\n"
 "Last-Translator: Susan Webster <susan@db.uc3m.es>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: es\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr "Marque para una búsqueda sensible a mayúsculas/minúsculas."
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr "Insertar el texto a encontrar."
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr "Insertar el texto a reemplazar el texto original."
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr "Buscar Que"
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "Marque aquí para una búsqueda recursiva sobre las carpetas seleccionadas y sus subcarpetas, con reemplazamiento en todos los niveles."
 
@@ -60,67 +72,75 @@ msgstr "Marque aquí para una búsqueda recursiva sobre las carpetas seleccionad
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr "Coincidir Mayúsculas y Minúsculas"
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr "Vista previa"
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr "Reemplazar"
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr "Reemplazar Con"
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr "Resetear"
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr "Buscar en Subcarpetas"
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr "Buscar y Reemplazar"
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr "Buscar y Reemplazar texto"
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr "Buscar y reemplazar texto encontrado en documentos."
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr "Buscar/Reemplazar"
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/fr/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/fr/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2016-03-23 14:48+0100\n"
 "Last-Translator: Gagaro <gagaro42@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,44 +16,56 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr "Contenu Affecté"
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr "Après"
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr "Avant"
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr "Cochez la case pour une recherche sensible à la casse."
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr "Entrez le texte à rechercher"
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr "Entrez le texte qui remplacera le texte original."
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr "Recherche rapide"
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr "Rechercher"
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr "Si coché, uniquement les types activés seront recherchés, sinon, tous les types sont recherchés."
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "Si coché, la recherche sera faite récursivement à travers tous les dossiers et leurs enfants, remplaçant à chaque niveau."
 
@@ -61,67 +73,75 @@ msgstr "Si coché, la recherche sera faite récursivement à travers tous les do
 msgid "Installs the collective.searchandreplace package"
 msgstr "Installe le paquet collective.searchandreplace"
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr "Ligne"
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr "Liste des types qui seront recherchés."
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr "Sensible à la casse"
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr "Nombre de résultats maximum"
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
-msgstr "Nombre de résultats maximum à afficher. Attention : cela n'a aucun effet sur le nombre de textes remplacés lorsque vous utilisez le bouton Remplacer directement sans utiliser l'Aperçu."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
+msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr "Caractères de texte maximum"
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr "Chemin"
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr "Aperçu"
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr "Remplacer"
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr "Remplacer par"
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr "Remplacé: ${old} -> ${new}"
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr "Restreindre les types activés."
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr "Rechercher dans les sous-dossiers"
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr "Rechercher et Remplacer"
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr "Paramètres de Rechercher et Remplacer"
@@ -131,19 +151,19 @@ msgstr "Paramètres de Rechercher et Remplacer"
 msgid "Search and Replace text"
 msgstr "Rechercher et Remplacer du texte"
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr "Rechercher et remplacer dans le dossier parent"
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr "Recherche et remplace le texte trouvé dans les documents."
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr "Texte recherché remplacé dans ${replaced} de ${items} instance(s)."
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr "Texte recherché remplacé dans toutes les ${items} instance(s)."
 
@@ -152,19 +172,23 @@ msgstr "Texte recherché remplacé dans toutes les ${items} instance(s)."
 msgid "Search/Replace"
 msgstr "Rechercher/Remplacer"
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr "Tout selectionner"
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr "Le nombre maximum de caractères à afficher avant et après le texte trouvé."
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr "Utilise le catalogue pour rechercher, comme le fait le formulaire de recherche. Cela permet uniquement de trouver des mots-clés, et non des tags HTML. Vous pouvez avoir certains champs texte qui ne seront pas trouvés de cette facon, vous pourrez donc trouver plus de contenus si non coché, mais cela sera plus lent. Peu importe ce paramètre, une fois une occurence trouvée, les textes de tous les champs texte pourront être remplacés."
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr "Quand 'Restreindre les types activés' est coché, uniquement les types séléctionnés seront recherchés. Sinon, la liste est ignorée."
 
@@ -173,6 +197,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr "Contenu affecté"

--- a/collective/searchandreplace/locales/hi/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/hi/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: hi\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/hu/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/hu/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: hu\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/it/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/it/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2009-07-30 14:38+0100\n"
 "Last-Translator: Antonio Fini <antonio.fini@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: it\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "Se selezionato, la ricerca sarà effettuata in modo ricorsivo in ogni cartella selezionata e relative sottocartelle ad ogni livello."
 
@@ -60,67 +72,75 @@ msgstr "Se selezionato, la ricerca sarà effettuata in modo ricorsivo in ogni ca
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr "Testo da cercare e sostituire"
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr "Cerca/Sostituisci"
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/ja/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/ja/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eduCommons\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2009-08-03 16:46+0900\n"
 "Last-Translator: Takeshi Yamamoto (Retsu) <tyam@mac.com>\n"
 "Language-Team: Takeshi Yamamoto <tyam@mac.com>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: plone\n"
 "Language: ja\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "チェックされていれば、選ばれたフォルダとその子フォルダをすべて再帰的に各レベルにおいて検索し置換します。"
 
@@ -60,67 +72,75 @@ msgstr "チェックされていれば、選ばれたフォルダとその子フ
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr "テキストを検索し置換"
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr "検索/置換"
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/ko/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/ko/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: ko\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/ne/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/ne/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: ne\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/nl/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/nl/LC_MESSAGES/SearchAndReplace.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.searchandreplace 3.2\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2016-07-19 18:34+0200\n"
 "Last-Translator: Maurits van Rees <m.van.rees@zestsoftware.nl>\n"
 "Language-Team: Plone Nederland <plone-plone-nl@lists.plone.org>\n"
@@ -16,44 +16,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: nl\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr "Te wijzigen inhoud"
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr "Na"
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr "Voor"
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr "Vink aan voor hoofdlettergevoelig zoeken."
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr "Vul de tekst in om naar te zoeken."
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr "Vul de tekst in om de oorspronkelijke tekst mee te vervangen."
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr "Snel zoeken"
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr "Zoek naar"
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr "Als deze optie is aangevinkt, worden velden met meerdere lijnen (zoals Tags) ook doorzocht, niet enkel titel en tekst velden"
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr "Als deze optie is aangevinkt, worden alleen de ingeschakelde types doorzocht, anders worden alle types doorzocht."
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr "Als deze optie is aangevinkt, worden enkele lijn velden ook doorzocht, niet enkel titel en tekst velden"
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr "Als deze optie is aangevinkt, worden de index/metadata van het object waarvan tekst is vervangen bijgewerkt"
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "Als deze optie is aangevinkt, wordt recursief gezocht door de map en alle onderliggende mappen en items, waarbij op elk niveau vervangen wordt."
 
@@ -61,67 +73,75 @@ msgstr "Als deze optie is aangevinkt, wordt recursief gezocht door de map en all
 msgid "Installs the collective.searchandreplace package"
 msgstr "Installeert het collective.searchandreplace package"
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr "Regel"
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr "Lijst van types die doorzocht worden."
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr "Hoofdlettergevoelig"
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr "Maximum aantal resultaten"
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
-msgstr "Maximum aantal resultaten om te tonen. Let op: dit heeft geen effect op hoeveel gevonden teksten vervangen worden als je direct de knop Vervangen gebruikt, zonder de Voorvertoning te gebruiken."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
+msgstr "Maximum aantal resultaten om te tonen. Let op: dit heeft enkel effect op hoeveel resultaten getoond worden in Voorvertoning. Het heeft geen efffect op het aantal teksten dat wordt vervangen als je op de knop Vervangen drukt."
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr "Maximum aantal karakters"
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr "Pad"
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr "Voorvertoning"
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr "Vervang"
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr "Vervang door"
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr "Vervangen: ${old} -> ${new}"
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr "Reset"
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr "Beperkt de ingeschakelde types."
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr "Doorzoek submappen"
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr "Zoek ook in velden met lijnen"
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr "Zoek ook in tekstvak velden"
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr "Zoek en vervang"
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr "Zoek en vervang-instellingen"
@@ -131,19 +151,19 @@ msgstr "Zoek en vervang-instellingen"
 msgid "Search and Replace text"
 msgstr "Zoek en vervang tekst"
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr "Zoek en vervang in de bovenliggende folder"
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr "Zoek en vervang tekst gevonden in documenten."
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr "Gezochte tekst vervangen in ${replaced} van ${items} geval(len)."
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr "Gezochte tekst vervangen in alle ${items} geval(len)."
 
@@ -152,19 +172,23 @@ msgstr "Gezochte tekst vervangen in alle ${items} geval(len)."
 msgid "Search/Replace"
 msgstr "Zoek/Vervang"
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr "Selecteer alle items"
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr "Maximum aantal karakters om te tonen voor en na de gevonden tekst."
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr "Werk de wijzigingsdatum bij na vervanging."
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr "Gebruik de catalogus om te zoeken, net zoals het zoekformulier doet. Dit vindt alleen woorden, geen html tags. Er kunnen tekstvelden zijn die op deze manier niet gevonden worden, dus als deze optie niet aangevinkt is, zou je meer inhoud kunnen vinden, maar het is langzamer. Ongeacht deze instelling: als minstens één overeenkomst is gevonden in een document, worden alle tekstvelden doorzocht."
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr "Als 'Beperkt de ingeschakelde types' is aangevinkt, worden alleen de geselecteerde types doorzocht. Anders wordt deze lijst genegeerd."
 
@@ -173,6 +197,6 @@ msgid "collective.searchandreplace"
 msgstr "collective.searchandreplace"
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr "Te wijzigen inhoud"

--- a/collective/searchandreplace/locales/pt-br/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/pt-br/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2012-08-09 17:14-0300\n"
 "Last-Translator: Gustavo Schwarz <gustavo.sne@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,46 +15,58 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: pt-br\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr "Marque para fazer uma busca que diferencie letas maiúsculas e minúsculas."
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr "Digite o texto que você deseja pesquisar."
 
 # I don't know if this is correct.
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 #, fuzzy
 msgid "Enter the text to replace the original text with."
 msgstr "Digite o texto que substituirá o texto original."
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr "Pesquisar por"
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "Se marcada, esta opção irá fazer uma busca recursiva em qualquer pasta selecionada e suas subpastas, fazendo a substituição em cada nível."
 
@@ -62,70 +74,78 @@ msgstr "Se marcada, esta opção irá fazer uma busca recursiva em qualquer past
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
 # I don't know if this is correct.
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 #, fuzzy
 msgid "Match Case"
 msgstr "Coincidir palavra inteira"
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 #, fuzzy
 msgid "Preview"
 msgstr "Visualização"
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr "Substituir"
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr "Substituir Por"
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr "Redefinir"
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr "Pesquisar Subdiretórios"
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr "Pesquisar e Substituir"
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -135,19 +155,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr "Pesquisar e Substituir texto"
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr "Pesquisar e substituir texto encontrado nos documentos."
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -156,19 +176,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr "Pesquisar/Substituir"
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -177,6 +201,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/pt/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/pt/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: pt\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/ru/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/ru/LC_MESSAGES/SearchAndReplace.po
@@ -1,8 +1,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2016-07-20 18:10+0500\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -12,166 +14,189 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: SearchAndReplace\n"
 "Language: ru\n"
-"Last-Translator: \n"
-"Language-Team: \n"
 "X-Generator: Poedit 1.8.8\n"
 
-#: browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr "Затронутое содержимое"
 
-#: browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr "После"
 
-#: browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr "До"
 
-#: browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr "Чувствительность к регистру."
 
-#: browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr "Введите текст для поиска."
 
-#: browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr "Введите текст для замены в оригинальном тексте."
 
-#: browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr "Быстрый поиск"
 
-#: browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr "Что ищем"
 
-#: interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr "Если отмеченон, просматриваются только выбранные типы , в противном случае просматриваются все типы."
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "Если отмечено. то ищется рекурсивно в любых выбранных папках и дочерних элементах, замена производится на каждом уровне."
 
-#: configure.zcml:28
+#: ./configure.zcml:28
 msgid "Installs the collective.searchandreplace package"
 msgstr "Поиск и замена текста в содержимом элементов. Ищет  в названии, описании и в тексте документа, по всем текстовым полям."
 
-#: browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr "Строка"
 
-#: interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr "Перечень типов для поиска"
 
-#: browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr "Учитывать регистр"
 
-#: browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr "Максимальное количество результатов"
 
-#: browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
-msgstr "Максимальное количество показываемых результатов. Внимание: это не имеет никакого влияния на количество найденных текстов, замена производится напрямую при использовании кнопки Заменить, без использования предварительного просмотра."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
+msgstr ""
 
-#: interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr "Максимум символов."
 
-#: browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr "Путь"
 
-#: browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
-#: browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr "Заменить"
 
-#: browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr "Заменить на"
 
-#: searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr "Заменено:  ${old} -> ${new}"
 
-#: browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr "Сброс"
 
-#: interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr "Ограничиться отмеченными типами."
 
-#: browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr "Искать в подпапках"
 
-#: browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr "Поиск и Замена"
 
-#: browser/controlpanel.py:16 profiles/default/controlpanel.xml
+#: ./browser/controlpanel.py:17
+#: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr "Настройки \"Поиск и Замена\""
 
 #. Default: "Search and Replace text"
-#: profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Search and Replace text"
 msgstr "Найти и заменить текст"
 
-#: browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr "Найти и заменить в родительской папке"
 
-#: browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr "Найти и заменить найденный текст в документах."
 
-#: browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr "Заменить найденный текст на ${replaced} в ${items} экземпляре(ах)."
 
-#: browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr "Заменить найденный текст во всех ${items} экземплярах"
 
 #. Default: "Search/Replace"
-#: profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Search/Replace"
 msgstr "Поиск/Замена"
 
-#: browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr "Выбрать все элементы"
 
-#: interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr "Максимальное количество символов, которые будет показаны до и после найденного текста."
 
-#: browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr "Используйте каталог для поиска, так же, как это делает форма поиска. Ищутся только ключевые слова, а не HTML-теги. Вы можете иметь некоторые текстовые поля, которые не нашли этот путь, так что если не установлен, вы можете найти больше содержания, но это будет медленнее. Вне зависимости от этого параметра, когда по крайней мере, найдено одно совпадение, текст во всех текстовых полях может быть заменён."
 
-#: interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr "Когда 'Ограничиться отмеченными типами.' отмечено, производится поиск только выбранных типов. В противном случае этот список игнорируется."
 
-#: configure.zcml:28
+#: ./configure.zcml:28
 msgid "collective.searchandreplace"
 msgstr "Поиск и Замена (collective.searchandreplace)"
 
 #. Default: "Affected content"
-#: browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr "Затронутое содержимое"

--- a/collective/searchandreplace/locales/tr/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/tr/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2009-08-04 11:12+0200\n"
 "Last-Translator: Nergis <nergis@metu.edu.tr>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: tr\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "Eğer işaretlenmişse, her seviyede değişim yaparak seçili klasör ve alt klasörleri arar."
 
@@ -60,67 +72,75 @@ msgstr "Eğer işaretlenmişse, her seviyede değişim yaparak seçili klasör v
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr "Metni Ara ve Değiştir"
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr "Ara/Değiştir"
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/vi/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/vi/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: vi\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/zh-cn/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/zh-cn/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2009-07-29 16:43-0700\n"
 "Last-Translator: Jessie Zhu <jessie.zhu@usu.edu>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: zh-cn\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "如果选取，将在所有选取的文件夹及其子文件夹递归搜索，替换每个阶层。"
 
@@ -60,67 +72,75 @@ msgstr "如果选取，将在所有选取的文件夹及其子文件夹递归搜
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr "搜索和替换文字"
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr "搜索/替换"
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/zh-hk/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/zh-hk/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: zh-hk\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr ""
 
@@ -60,67 +72,75 @@ msgstr ""
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr ""
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/zh-tw/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/zh-tw/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2009-08-02 10:43+0800\n"
 "Last-Translator: Haishuo Lee <haishuolee@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: zh-tw\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "如果勾選，將會遞迴搜尋所有選取檔案與其子檔案，並在每個層級進行替換。"
 
@@ -60,67 +72,75 @@ msgstr "如果勾選，將會遞迴搜尋所有選取檔案與其子檔案，並
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr "搜尋並替換文字"
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr "搜尋/替換"
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""

--- a/collective/searchandreplace/locales/zh/LC_MESSAGES/SearchAndReplace.po
+++ b/collective/searchandreplace/locales/zh/LC_MESSAGES/SearchAndReplace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-19 16:34+0000\n"
+"POT-Creation-Date: 2021-05-25 11:07+0000\n"
 "PO-Revision-Date: 2009-07-29 16:43-0700\n"
 "Last-Translator: Jessie Zhu <jessie.zhu@usu.edu>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,44 +15,56 @@ msgstr ""
 "Domain: SearchAndReplace\n"
 "Language: zh\n"
 
-#: ./browser/searchreplacetable.pt:13
+#: ./browser/searchreplacetable.pt:14
 msgid "Affected Content"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:33
+#: ./browser/searchreplacetable.pt:46
 msgid "After"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:32
+#: ./browser/searchreplacetable.pt:45
 msgid "Before"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:57
+#: ./browser/searchreplaceform.py:63
 msgid "Check the box for a case sensitive search."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:28
+#: ./browser/searchreplaceform.py:29
 msgid "Enter the text to find."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:33
+#: ./browser/searchreplaceform.py:34
 msgid "Enter the text to replace the original text with."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:62
+#: ./browser/searchreplaceform.py:69
 msgid "Fast search"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:27
+#: ./browser/searchreplaceform.py:29
 msgid "Find What"
 msgstr ""
 
-#: ./interfaces.py:32
+#: ./interfaces.py:96
+msgid "If checked, multiple lines fields like subject will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:33
 msgid "If checked, only the enabled types are searched, otherwise all types are searched."
 msgstr ""
 
+#: ./interfaces.py:85
+msgid "If checked, single line fields will also be searched and replaced, not only title and text fields."
+msgstr ""
+
+#: ./interfaces.py:75
+msgid "If checked, the modified index/metadata of the object having text replaced will be updated."
+msgstr ""
+
 #. Default: "If checked, this will recursively search through any selected folders and their children, replacing at each level."
-#: ./browser/searchreplaceform.py:48
+#: ./browser/searchreplaceform.py:52
 msgid "If checked, this will recursively search through any selected folders and their children, replacing at each level."
 msgstr "如果选取，将在所有选取的文件夹及其子文件夹递归搜索，替换每个阶层。"
 
@@ -60,67 +72,75 @@ msgstr "如果选取，将在所有选取的文件夹及其子文件夹递归搜
 msgid "Installs the collective.searchandreplace package"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:31
+#: ./browser/searchreplacetable.pt:44
 msgid "Line"
 msgstr ""
 
-#: ./interfaces.py:40
+#: ./interfaces.py:42
 msgid "List of types that are searched."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:56
+#: ./browser/searchreplaceform.py:62
 msgid "Match Case"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:37
+#: ./browser/searchreplaceform.py:39
 msgid "Maximum Number of Results"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:38
-msgid "Maximum number of results to show. Warning: this has no effect on how many found texts are replaced when you use the Replace button directly without using the Preview."
+#: ./browser/searchreplaceform.py:40
+msgid "Maximum number of results to show. Warning: this only affects how many preview results are shown. It has no effect on how many found texts are replaced when you use the Replace button."
 msgstr ""
 
-#: ./interfaces.py:61
+#: ./interfaces.py:64
 msgid "Maximum text characters"
 msgstr ""
 
-#: ./browser/searchreplacetable.pt:30
+#: ./browser/searchreplacetable.pt:41
 msgid "Path"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:94
+#: ./browser/searchreplaceform.py:103
 msgid "Preview"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:101
+#: ./browser/searchreplaceform.py:115
 msgid "Replace"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:32
+#: ./browser/searchreplaceform.py:33
 msgid "Replace With"
 msgstr ""
 
-#: ./searchreplaceutility.py:156
+#: ./searchreplaceutility.py:224
 msgid "Replaced: ${old} -> ${new}"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:146
+#: ./browser/searchreplaceform.py:170
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces.py:31
+#: ./interfaces.py:32
 msgid "Restrict the enabled types."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:47
+#: ./browser/searchreplaceform.py:51
 msgid "Search Subfolders"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:90
+#: ./interfaces.py:95
+msgid "Search also lines fields"
+msgstr ""
+
+#: ./interfaces.py:84
+msgid "Search also textline fields"
+msgstr ""
+
+#: ./browser/searchreplaceform.py:99
 msgid "Search and Replace"
 msgstr ""
 
-#: ./browser/controlpanel.py:16
+#: ./browser/controlpanel.py:17
 #: ./profiles/default/controlpanel.xml
 msgid "Search and Replace settings"
 msgstr ""
@@ -130,19 +150,19 @@ msgstr ""
 msgid "Search and Replace text"
 msgstr "搜索和替换文字"
 
-#: ./browser/pageform.pt:50
+#: ./browser/pageform.pt:56
 msgid "Search and replace in parent folder"
 msgstr ""
 
-#: ./browser/searchreplaceform.py:91
+#: ./browser/searchreplaceform.py:100
 msgid "Search and replace text found in documents."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:127
+#: ./browser/searchreplaceform.py:145
 msgid "Search text replaced in ${replaced} of ${items} instance(s)."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:142
+#: ./browser/searchreplaceform.py:163
 msgid "Search text replaced in all ${items} instance(s)."
 msgstr ""
 
@@ -151,19 +171,23 @@ msgstr ""
 msgid "Search/Replace"
 msgstr "搜索/替换"
 
-#: ./browser/searchreplacetable.pt:20
+#: ./browser/searchreplacetable.pt:29
 msgid "Select all items"
 msgstr ""
 
-#: ./interfaces.py:62
+#: ./interfaces.py:65
 msgid "The maximum number of characters to show before and after the found text."
 msgstr ""
 
-#: ./browser/searchreplaceform.py:63
+#: ./interfaces.py:74
+msgid "Update the modified datetime when replacing."
+msgstr ""
+
+#: ./browser/searchreplaceform.py:70
 msgid "Use the catalog to search, just like the search form does. This only finds keywords, not html tags. You might have some text fields that are not found this way, so if not checked, you may find more content, but it will be slower. Regardless of this setting, when at least one match is found, text in all text fields may be replaced."
 msgstr ""
 
-#: ./interfaces.py:41
+#: ./interfaces.py:43
 msgid "When 'Restrict the enable types' is checked, only the selected types are searched. Otherwise this list is ignored."
 msgstr ""
 
@@ -172,6 +196,6 @@ msgid "collective.searchandreplace"
 msgstr ""
 
 #. Default: "Affected content"
-#: ./browser/searchreplacetable.pt:16
+#: ./browser/searchreplacetable.pt:20
 msgid "summary_affected_content"
 msgstr ""


### PR DESCRIPTION
This could lead to user replacing a lot of instances without intent.

Solution: Show Replace button only when there are preview results.
proxied by `form.actions.Preview` or `from.actions.Replace` in request.