### PR TITLE
Do not destroy the title "Object actions" in the category of actions

### DIFF
--- a/collective/searchandreplace/profiles/default/actions.xml
+++ b/collective/searchandreplace/profiles/default/actions.xml
@@ -3,7 +3,6 @@
         xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <object name="object" meta_type="CMF Action Category">
-    <property name="title"></property>
     <object name="search_and_replace" meta_type="CMF Action" i18n:domain="SearchAndReplace">
       <property name="title" i18n:translate="">Search/Replace</property>
       <property name="description" i18n:translate="">Search and Replace text</property>


### PR DESCRIPTION
Fixes the title of the action category disappearing (and displaying `object` instead) when installing this addon.