### PR TITLE
fix the search in folder that is set as default item of the parent folder

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
         - ["3.9",   "plone60-py39"]
         - ["3.10",  "plone60-py310"]
         - ["3.11",  "plone60-py311"]
+        - ["3.12",  "plone60-py312"]
     runs-on: ubuntu-20.04
     name: ${{ matrix.config[1] }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-20.04
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
@@ -47,7 +47,7 @@ jobs:
         echo "[buildout]" >> ~/.buildout/default.cfg
         echo "eggs-directory = ~/eggs" >> ~/.buildout/default.cfg
     - name: Cache eggs
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/eggs
         key: ${{ runner.os }}-eggs-${{ matrix.config[0] }}-${{ matrix.config[1] }}-${{ hashFiles('*cfg') }}
@@ -70,6 +70,6 @@ jobs:
       image: ${{ matrix.config[1] }}
     name: ${{ matrix.config[0] }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test
       run: tox -e ${{ matrix.config[0] }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,11 @@ Changelog
 8.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix the search in a folder that is set as the default view of the parent folder. [Mychae1]
 
+- Add tests for calculating the path to start the search from. [Mychae1]
+
+- Also test under python 3.12. [gotcha]
 
 8.3 (2023-09-25)
 ----------------

--- a/collective/searchandreplace/pytests/zope_instance.py
+++ b/collective/searchandreplace/pytests/zope_instance.py
@@ -2,7 +2,12 @@ import os
 import sys
 import time
 import subprocess
-import pathlib2 as pathlib
+
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
+
 import socket
 from contextlib import closing
 
@@ -27,13 +32,11 @@ class ZopeInstance(object):
         ).parent.joinpath("buildout")
         package_path = pytestconfig.rootdir
         buildout_cfg = pathlib.Path(tmp_path, "buildout.cfg")
-        buildout = u"""
+        buildout = """
 [buildout]
 extends =  %(package_path)s/buildout.cfg
 develop =  %(package_path)s
-""" % dict(
-            package_path=package_path
-        )
+""" % dict(package_path=package_path)
         with buildout_cfg.open("w") as f:
             f.write(buildout)
         os.chdir(str(tmp_path))

--- a/collective/searchandreplace/searchreplaceutility.py
+++ b/collective/searchandreplace/searchreplaceutility.py
@@ -69,7 +69,7 @@ def make_catalog_query_args(context, findWhat, searchSubFolders, onlySearchableT
     if context.isPrincipiaFolderish and not searchSubFolders:
         query["depth"] = 1
     container = aq_parent(context)
-    if isDefaultPage(container, context) and searchSubFolders:
+    if isDefaultPage(container, context) and not context.isPrincipiaFolderish and searchSubFolders:
         query["query"] = "/".join(container.getPhysicalPath())
     catalog_query_args = dict(path=query)
     if settings().restrict_searchable_types:

--- a/collective/searchandreplace/testing.py
+++ b/collective/searchandreplace/testing.py
@@ -39,7 +39,12 @@ class SearchReplaceLayer(PloneSandboxLayer):
 
         applyProfile(portal, "collective.searchandreplace:default")
         setRoles(portal, TEST_USER_ID, ["Manager"])
-        create_doc(portal, text=u"Get Plone now", title=u"Plone", description=u"Plone")
+        create_doc(
+            portal,
+            text=u"<p>Get Plone now [text]</p>",
+            title=u"Get Plone now [title]",
+            description=u"Get Plone now [description]",
+        )
         setRoles(portal, TEST_USER_ID, ["Member"])
 
 
@@ -68,7 +73,9 @@ def rich_text(text):
 
 def create_doc(container, id="page", title=u"Title of page", text=u"", description=u""):
     text = rich_text(text)
-    api.content.create(container, "Document", id=id, title=title, text=text, description=description)
+    api.content.create(
+        container, "Document", id=id, title=title, text=text, description=description
+    )
 
 
 def edit_content(

--- a/collective/searchandreplace/tests/basicsearch.txt
+++ b/collective/searchandreplace/tests/basicsearch.txt
@@ -22,7 +22,11 @@ Test to ensure basic search and replace works. Search for 'get' and check previe
 for results.
 
     >>> browser.open(portal_url + '/page')
-    >>> "Get Plone now" in browser.contents
+    >>> "Get Plone now [text]" in browser.contents
+    True
+    >>> "Get Plone now [title]" in browser.contents
+    True
+    >>> "Get Plone now [description]" in browser.contents
     True
     >>> "Love Plone now" in browser.contents
     False
@@ -41,7 +45,15 @@ Replace "get" with "love".
 View page to verify replacement was made.
 
     >>> browser.open(portal_url + '/page')
-    >>> "Love Plone now" in browser.contents
+    >>> "Love Plone now [text]" in browser.contents
     True
-    >>> "Get Plone now" in browser.contents
+    >>> "Get Plone now [text]" in browser.contents
+    False
+    >>> "Love Plone now [title]" in browser.contents
+    True
+    >>> "Get Plone now [title]" in browser.contents
+    False
+    >>> "Love Plone now [description]" in browser.contents
+    True
+    >>> "Get Plone now [description]" in browser.contents
     False

--- a/collective/searchandreplace/tests/filterfields.txt
+++ b/collective/searchandreplace/tests/filterfields.txt
@@ -29,11 +29,11 @@ and check for three results, one per field.
     ['description', 'text', 'title']
     >>> browser.getControl(name='form.widgets.filterFields').value
     ['description', 'text', 'title']
-    >>> 'title:0:/plone/page' in browser.getControl(name='form.affectedContent').options
+    >>> 'title:4:/plone/page' in browser.getControl(name='form.affectedContent').options
     True
-    >>> 'description 1:0:/plone/page' in browser.getControl(name='form.affectedContent').options
+    >>> 'description 1:4:/plone/page' in browser.getControl(name='form.affectedContent').options
     True
-    >>> 'text 1:4:/plone/page' in browser.getControl(name='form.affectedContent').options
+    >>> 'text 1:7:/plone/page' in browser.getControl(name='form.affectedContent').options
     True
 
 Show content only from title field.
@@ -44,7 +44,7 @@ Show content only from title field.
     ['description', 'text', 'title']
     >>> browser.getControl(name='form.widgets.filterFields').value
     ['title']
-    >>> 'title:0:/plone/page' in browser.getControl(name='form.affectedContent').options
+    >>> 'title:4:/plone/page' in browser.getControl(name='form.affectedContent').options
     True
 
 Show content from text and description fields.
@@ -56,7 +56,7 @@ Show content from text and description fields.
     >>> browser.getControl(name='form.widgets.filterFields').value
     ['description', 'text']
     >>> browser.getControl(name='form.affectedContent').options
-    ['description 1:0:/plone/page', 'text 1:4:/plone/page']
+    ['description 1:4:/plone/page', 'text 1:7:/plone/page']
 
 Unchecking all fields resets filter.
 
@@ -66,9 +66,9 @@ Unchecking all fields resets filter.
     ['description', 'text', 'title']
     >>> browser.getControl(name='form.widgets.filterFields').value
     ['description', 'text', 'title']
-    >>> 'title:0:/plone/page' in browser.getControl(name='form.affectedContent').options
+    >>> 'title:4:/plone/page' in browser.getControl(name='form.affectedContent').options
     True
-    >>> 'description 1:0:/plone/page' in browser.getControl(name='form.affectedContent').options
+    >>> 'description 1:4:/plone/page' in browser.getControl(name='form.affectedContent').options
     True
-    >>> 'text 1:4:/plone/page' in browser.getControl(name='form.affectedContent').options
+    >>> 'text 1:7:/plone/page' in browser.getControl(name='form.affectedContent').options
     True

--- a/collective/searchandreplace/tests/test_matchcase.py
+++ b/collective/searchandreplace/tests/test_matchcase.py
@@ -55,12 +55,30 @@ class TestMatchCase(unittest.TestCase):
         )
         self.assertEqual(len(results), 1)
 
+
+
+class TestPath(unittest.TestCase):
+    layer = SEARCH_REPLACE_INTEGRATION_LAYER
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.srutil = getUtility(ISearchReplaceUtility)
+
     def testPathItem(self):
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         self.portal.invokeFactory("Document", "doc1")
         doc1 = getattr(self.portal, "doc1")
 
         catalog_query_args = make_catalog_query_args(context=doc1, findWhat="Find", searchSubFolders=True, onlySearchableText=False)
+        path = catalog_query_args["path"]["query"]
+        self.assertEqual(path, '/plone/doc1')
+
+    def testPathItemNoSubFolders(self):
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Document", "doc1")
+        doc1 = getattr(self.portal, "doc1")
+
+        catalog_query_args = make_catalog_query_args(context=doc1, findWhat="Find", searchSubFolders=False, onlySearchableText=False)
         path = catalog_query_args["path"]["query"]
         self.assertEqual(path, '/plone/doc1')
 
@@ -73,6 +91,15 @@ class TestMatchCase(unittest.TestCase):
         path = catalog_query_args["path"]["query"]
         self.assertEqual(path, '/plone/mainfolder')
 
+    def testPathFolderNoSubFolders(self):
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Folder", "mainfolder")
+        mainfolder = getattr(self.portal, "mainfolder")
+
+        catalog_query_args = make_catalog_query_args(context=mainfolder, findWhat="Find", searchSubFolders=False, onlySearchableText=False)
+        path = catalog_query_args["path"]["query"]
+        self.assertEqual(path, '/plone/mainfolder')
+
     def testPathItemDefaultView(self):
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         self.portal.invokeFactory("Document", "index_html")
@@ -81,6 +108,14 @@ class TestMatchCase(unittest.TestCase):
         path = catalog_query_args["path"]["query"]
         self.assertEqual(path, '/plone')
 
+    def testPathItemDefaultViewNoSubFolders(self):
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Document", "index_html")
+
+        catalog_query_args = make_catalog_query_args(context=self.portal.index_html, findWhat="Find", searchSubFolders=False, onlySearchableText=False)
+        path = catalog_query_args["path"]["query"]
+        self.assertEqual(path, '/plone/index_html')
+
     def testPathFolderDefaultView(self):
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         self.portal.invokeFactory("Folder", "index_html")
@@ -88,6 +123,15 @@ class TestMatchCase(unittest.TestCase):
         catalog_query_args = make_catalog_query_args(context=self.portal.index_html, findWhat="Find", searchSubFolders=True, onlySearchableText=False)
         path = catalog_query_args["path"]["query"]
         self.assertEqual(path, '/plone/index_html')
+
+    def testPathFolderDefaultViewNoSubFolders(self):
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Folder", "index_html")
+
+        catalog_query_args = make_catalog_query_args(context=self.portal.index_html, findWhat="Find", searchSubFolders=False, onlySearchableText=False)
+        path = catalog_query_args["path"]["query"]
+        self.assertEqual(path, '/plone/index_html')
+
 
 
 class TestMultipleMatchCase(unittest.TestCase):

--- a/collective/searchandreplace/tests/test_matchcase.py
+++ b/collective/searchandreplace/tests/test_matchcase.py
@@ -7,6 +7,8 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from zope.component import getUtility
 
+from collective.searchandreplace.searchreplaceutility import make_catalog_query_args
+
 import unittest
 
 
@@ -52,6 +54,40 @@ class TestMatchCase(unittest.TestCase):
             # occurences=paths
         )
         self.assertEqual(len(results), 1)
+
+    def testPathItem(self):
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Document", "doc1")
+        doc1 = getattr(self.portal, "doc1")
+
+        catalog_query_args = make_catalog_query_args(context=doc1, findWhat="Find", searchSubFolders=True, onlySearchableText=False)
+        path = catalog_query_args["path"]["query"]
+        self.assertEqual(path, '/plone/doc1')
+
+    def testPathFolder(self):
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Folder", "mainfolder")
+        mainfolder = getattr(self.portal, "mainfolder")
+
+        catalog_query_args = make_catalog_query_args(context=mainfolder, findWhat="Find", searchSubFolders=True, onlySearchableText=False)
+        path = catalog_query_args["path"]["query"]
+        self.assertEqual(path, '/plone/mainfolder')
+
+    def testPathItemDefaultView(self):
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Document", "index_html")
+
+        catalog_query_args = make_catalog_query_args(context=self.portal.index_html, findWhat="Find", searchSubFolders=True, onlySearchableText=False)
+        path = catalog_query_args["path"]["query"]
+        self.assertEqual(path, '/plone')
+
+    def testPathFolderDefaultView(self):
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Folder", "index_html")
+
+        catalog_query_args = make_catalog_query_args(context=self.portal.index_html, findWhat="Find", searchSubFolders=True, onlySearchableText=False)
+        path = catalog_query_args["path"]["query"]
+        self.assertEqual(path, '/plone/index_html')
 
 
 class TestMultipleMatchCase(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,15 @@ import sys
 
 pytest_extras = [
     "pytest",
-    "gocept.pytestlayer",
     "requests",
 ]
 if sys.version_info[0] == 2:
     pytest_extras.append("pathlib2")
+    pytest_extras.append("gocept.pytestlayer")
+if sys.version_info[0] == 3 and sys.version_info[1] <= 11:
+    pytest_extras.append("gocept.pytestlayer")
+if sys.version_info[0] == 3 and sys.version_info[1] >= 12:
+    pytest_extras.append("zope.pytestlayer")
 
 
 version = "8.3.1.dev0"

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,16 @@
 ##############################################################################
 
 from setuptools import setup, find_packages
+import sys
+
+pytest_extras = [
+    "pytest",
+    "gocept.pytestlayer",
+    "requests",
+]
+if sys.version_info[0] == 2:
+    pytest_extras.append("pathlib2")
+
 
 version = "8.3.1.dev0"
 
@@ -82,12 +92,7 @@ setup(
             "collective.dexteritytextindexer",
             "plone.app.testing",
         ],
-        pytest=[
-            "pytest",
-            "gocept.pytestlayer",
-            "pathlib2",
-            "requests",
-        ],
+        pytest=pytest_extras,
     ),
     entry_points="""
     # -*- Entry points: -*-

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     plone43-py27
     plone51-py27
     plone52-py{27,36,37,38}
-    plone60-py{38,39,310,311}
+    plone60-py{38,39,310,311,312}
 
 [testenv]
 # We do not install with pip, but with buildout:
@@ -13,7 +13,7 @@ skip_install = true
 deps =
     py27: -r requirements-py27.txt
     plone52-py{36,37,38}: -r requirements-{envname}.txt
-    plone60-py{38,39,310,311}: -r requirements-plone60.txt
+    plone60-py{38,39,310,311,312}: -r requirements-plone60.txt
 commands_pre =
     plone43: {envbindir}/buildout -Nc {toxinidir}/test-4.3.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install pytest
     plone51: {envbindir}/buildout -Nc {toxinidir}/test-5.1.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install pytest

--- a/versions.cfg
+++ b/versions.cfg
@@ -23,3 +23,6 @@ gocept.pytestlayer = 6.3
 [versions:python3]
 pytest = 7.2.1
 gocept.pytestlayer = 8.1
+
+[versions:python312]
+zope.pytestlayer = 8.2


### PR DESCRIPTION
When a page is set as default view in folder "foo", then the search will look in folder foo when searching on the page.
When a folder "bar" is set as default view of the folder foo, the search will search in foo instead of folder bar when doing the search on bar, while it should search on bar instead (in my opinion)